### PR TITLE
Enable right-click context menu in all mouse modes (#91)

### DIFF
--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -482,9 +482,10 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                 return
             plot = ci.plot()
             if event.button == MouseButton.RIGHT:
-                for attr in ('_zoom_info', '_pan_info'):
-                    if getattr(self._mpl_toolbar, attr, None) is not None:
-                        setattr(self._mpl_toolbar, attr, None)
+                if getattr(self._mpl_toolbar, '_zoom_info', None) is not None:
+                    self._mpl_toolbar.release_zoom(event)
+                if getattr(self._mpl_toolbar, '_pan_info', None) is not None:
+                    self._mpl_toolbar.release_pan(event)
                 self._show_autoscale_menu(event)
                 return
             if self._mmode in [Canvas.MOUSE_MODE_ZOOM, Canvas.MOUSE_MODE_PAN]:

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -481,6 +481,12 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             if not hasattr(ci, 'plot'):
                 return
             plot = ci.plot()
+            if event.button == MouseButton.RIGHT:
+                for attr in ('_zoom_info', '_pan_info'):
+                    if getattr(self._mpl_toolbar, attr, None) is not None:
+                        setattr(self._mpl_toolbar, attr, None)
+                self._show_autoscale_menu(event)
+                return
             if self._mmode in [Canvas.MOUSE_MODE_ZOOM, Canvas.MOUSE_MODE_PAN]:
                 # Stage a command to obtain original view limits
                 # Disable Zoom and Pan for PlotContour and for PlotContourWithSlider
@@ -488,26 +494,6 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                     return
                 self.stage_view_lim_cmd(event.inaxes)
                 return
-            if self._mmode == Canvas.MOUSE_MODE_SELECT and event.button == MouseButton.RIGHT:
-                # Create menu with autoscale options
-                autoscale_menu = QMenu(self)
-                autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(event.inaxes))
-                autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
-                if self._parser.canvas.focus_plot is None:
-                    autoscale_menu.addAction("Focus on plot", lambda: self._full_screen_mode_on(event.inaxes))
-                else:
-                    autoscale_menu.addAction("Unfocus plot", self._full_screen_mode_off)
-                autoscale_menu.addSeparator()
-                ci = self._parser._impl_plot_cache_table.get_cache_item(event.inaxes)
-                if ci:
-                    autoscale_menu.addAction("Preferences",
-                                             lambda: self.openPlotPreferences.emit(ci.plot()))
-                # Detect nearest signal and add Signal Preferences option
-                nearest_signal, _, _ = self._find_signal_at_event(event)
-                if nearest_signal:
-                    autoscale_menu.addAction("Signal Preferences",
-                                             lambda s=nearest_signal: self.openPlotPreferences.emit(s))
-                autoscale_menu.popup(event.guiEvent.globalPos())
 
             # Handle drag shift in Select mode with left click - use native hit-testing
             if self._mmode == Canvas.MOUSE_MODE_SELECT and event.button == MouseButton.LEFT:
@@ -599,6 +585,27 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                     self.push_view_lim_cmd()
                 # Update statistics
                 self.stats(self.get_canvas())
+
+    def _show_autoscale_menu(self, event: MouseEvent):
+        if event.inaxes is None:
+            return
+        ci = self._parser._impl_plot_cache_table.get_cache_item(event.inaxes)
+        autoscale_menu = QMenu(self)
+        autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(event.inaxes))
+        autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
+        if self._parser.canvas.focus_plot is None:
+            autoscale_menu.addAction("Focus on plot", lambda: self._full_screen_mode_on(event.inaxes))
+        else:
+            autoscale_menu.addAction("Unfocus plot", self._full_screen_mode_off)
+        autoscale_menu.addSeparator()
+        if ci:
+            autoscale_menu.addAction("Preferences",
+                                     lambda: self.openPlotPreferences.emit(ci.plot()))
+        nearest_signal, _, _ = self._find_signal_at_event(event)
+        if nearest_signal:
+            autoscale_menu.addAction("Signal Preferences",
+                                     lambda s=nearest_signal: self.openPlotPreferences.emit(s))
+        autoscale_menu.popup(event.guiEvent.globalPos())
 
     def keyPressEvent(self, event: QKeyEvent):
         if event.text() == 'n':

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -91,6 +91,7 @@ class QtViewBox(pg.ViewBox):
         # Right click PAN has no effect
         if ev.button() == Qt.MouseButton.RightButton and self.getState()['mouseEnabled'] == [True, True]:
             ev.accept()
+            self.released.emit(self, ev)
             return
         super().mousePressEvent(ev)
         self.pressed.emit(self, ev)

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -86,12 +86,15 @@ class QtViewBox(pg.ViewBox):
     def __init__(self, parent=None):
         super().__init__(parent=parent, enableMenu=False)
         self.sigRangeChangedManually.connect(self.release_event)
+        self._right_click_pan_handled = False
 
     def mousePressEvent(self, ev):
+        self._right_click_pan_handled = False
         # Right click PAN has no effect
         if ev.button() == Qt.MouseButton.RightButton and self.getState()['mouseEnabled'] == [True, True]:
             ev.accept()
             self.released.emit(self, ev)
+            self._right_click_pan_handled = True
             return
         super().mousePressEvent(ev)
         self.pressed.emit(self, ev)
@@ -103,14 +106,16 @@ class QtViewBox(pg.ViewBox):
 
     def mouseReleaseEvent(self, ev):
         super().mouseReleaseEvent(ev)
-        self.released.emit(self, ev)
+        if not self._right_click_pan_handled:
+            self.released.emit(self, ev)
 
     def release_event(self):
         self.released.emit(self, None)
 
     def mouseClickEvent(self, ev):
         super().mouseClickEvent(ev)
-        self.released.emit(self, ev)
+        if not self._right_click_pan_handled:
+            self.released.emit(self, ev)
 
     def wheelEvent(self, ev, axis=None):
         ev.ignore()

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -41,9 +41,6 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         self.setLayout(self._vlayout)
         self.set_canvas(kwargs.get('canvas'))
 
-        # QMenu
-        self.autoscale_menu = None
-
         # Drag & Drop
         self.setAcceptDrops(True)
 
@@ -331,9 +328,6 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                             f"Cannot add marker {new_marker}: found {marker_signal} samples, but the maximum allowed is 100")
                 else:
                     logger.warning("Markers must be enabled in the plot to create signal markers")
-
-            elif self._mmode == Canvas.MOUSE_MODE_SELECT:
-                self.autoscale_menu = None
         else:
             # Single click handling
             if self._mmode in [Canvas.MOUSE_MODE_ZOOM, Canvas.MOUSE_MODE_PAN]:
@@ -345,7 +339,6 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                 return
 
             elif self._mmode == Canvas.MOUSE_MODE_SELECT:
-                self.autoscale_menu = None
                 # Handle drag shift with left click
                 if event.button() == Qt.MouseButton.LeftButton:
                     signal, y_coord = self._find_signal_at_event(view_box, event)
@@ -435,31 +428,29 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
             # Update statistics
             self.stats(self.get_canvas())
 
-        elif self._mmode in [Canvas.MOUSE_MODE_SELECT]:
-            if event is None or event.button() == Qt.MouseButton.LeftButton or event.double():
-                return
-
-            # Create menu with autoscale options
-            if self.autoscale_menu is None:
-                self.autoscale_menu = QMenu(self)
-                self.autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(impl_plot))
-                self.autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
-                if self._parser.canvas.focus_plot is None:
-                    self.autoscale_menu.addAction("Focus on plot",
-                                                  lambda: self._full_screen_mode_on(impl_plot))
-                else:
-                    self.autoscale_menu.addAction("Unfocus plot", self._full_screen_mode_off)
-                self.autoscale_menu.addSeparator()
-                ci = self._parser._impl_plot_cache_table.get_cache_item(impl_plot)
-                if ci:
-                    self.autoscale_menu.addAction("Preferences",
-                                                  lambda: self.openPlotPreferences.emit(ci.plot()))
-                # Detect nearest signal and add Signal Preferences option
-                nearest_signal, _ = self._find_signal_at_event(view_box, event)
-                if nearest_signal:
-                    self.autoscale_menu.addAction("Signal Preferences",
-                                                  lambda s=nearest_signal: self.openPlotPreferences.emit(s))
-                self.autoscale_menu.popup(event.screenPos().toPoint())
+        is_double = callable(getattr(event, 'double', None)) and event.double()
+        if event is not None and event.button() == Qt.MouseButton.RightButton and not is_double:
+            autoscale_menu = QMenu(self)
+            autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(impl_plot))
+            autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
+            if self._parser.canvas.focus_plot is None:
+                autoscale_menu.addAction("Focus on plot",
+                                         lambda: self._full_screen_mode_on(impl_plot))
+            else:
+                autoscale_menu.addAction("Unfocus plot", self._full_screen_mode_off)
+            autoscale_menu.addSeparator()
+            ci = self._parser._impl_plot_cache_table.get_cache_item(impl_plot)
+            if ci:
+                autoscale_menu.addAction("Preferences",
+                                         lambda: self.openPlotPreferences.emit(ci.plot()))
+            nearest_signal, _ = self._find_signal_at_event(view_box, event)
+            if nearest_signal:
+                autoscale_menu.addAction("Signal Preferences",
+                                         lambda s=nearest_signal: self.openPlotPreferences.emit(s))
+            screen_pos = event.screenPos()
+            if hasattr(screen_pos, 'toPoint'):
+                screen_pos = screen_pos.toPoint()
+            autoscale_menu.popup(screen_pos)
 
     def mouse_clicked(self, event):
         if not event.currentItem:


### PR DESCRIPTION
The plot context menu (autoscale, focus, preferences) was only
reachable in select mode, so users had to leave zoom or pan to
open it.

It now appears in every mouse mode on both backends. Matplotlib's
right-drag zoom-out is disabled as part of this — autoscale from
the menu covers the reset-view intent.

A couple of smaller things cleaned up along the way: the menu was
cached and reused, which left the Focus/Unfocus label stale after
the first click, so it's now rebuilt on every right-click. And in
pyqtgraph's pan mode, right-clicks were being swallowed to block
the default drag-zoom; the release signal now fires alongside so
the menu handler runs, with a defensive screenPos conversion since
the event type there differs from the click path.