### PR TITLE
Apply canvas font size to crosshair labels (#93)

### DIFF
--- a/iplotlib/impl/matplotlib/matplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/matplotlibCanvas.py
@@ -1269,7 +1269,7 @@ class MatplotlibParser(BackendParserBase):
                                  lw=self.canvas.crosshair_line_width,
                                  horiz_on=False or self.canvas.crosshair_horizontal,
                                  vert_on=self.canvas.crosshair_vertical,
-                                 font_size=self._pm.get_value(self.canvas, 'font_size') or 8,
+                                 font_size=int(self._pm.get_value(self.canvas, 'font_size') or 8),
                                  use_blit=True,
                                  cache_table=self._impl_plot_cache_table))
 

--- a/iplotlib/impl/matplotlib/matplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/matplotlibCanvas.py
@@ -1269,6 +1269,7 @@ class MatplotlibParser(BackendParserBase):
                                  lw=self.canvas.crosshair_line_width,
                                  horiz_on=False or self.canvas.crosshair_horizontal,
                                  vert_on=self.canvas.crosshair_vertical,
+                                 font_size=self._pm.get_value(self.canvas, 'font_size') or 8,
                                  use_blit=True,
                                  cache_table=self._impl_plot_cache_table))
 

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -1696,6 +1696,8 @@ class PyQtGraphParser(BackendParserBase):
         horiz_on = bool(getattr(self.canvas, 'crosshair_horizontal', False))
         vert_on = bool(getattr(self.canvas, 'crosshair_vertical', True))
 
+        font_size = self._pm.get_value(self.canvas, 'font_size') or 8
+
         if getattr(self.canvas, 'crosshair_per_plot', False):
             for p in plots:
                 cursor = pyQtCrosshair(
@@ -1708,6 +1710,7 @@ class PyQtGraphParser(BackendParserBase):
                     horiz_on=horiz_on,
                     vert_on=vert_on,
                     val_tolerance=0.05,
+                    font_size=font_size,
                     cache_table=self._impl_plot_cache_table,
                 )
                 self._cursors.append(cursor)
@@ -1722,6 +1725,7 @@ class PyQtGraphParser(BackendParserBase):
                 horiz_on=horiz_on,
                 vert_on=vert_on,
                 val_tolerance=0.05,
+                font_size=font_size,
                 cache_table=self._impl_plot_cache_table,
             )
             self._cursors.append(cursor)

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -1696,7 +1696,7 @@ class PyQtGraphParser(BackendParserBase):
         horiz_on = bool(getattr(self.canvas, 'crosshair_horizontal', False))
         vert_on = bool(getattr(self.canvas, 'crosshair_vertical', True))
 
-        font_size = self._pm.get_value(self.canvas, 'font_size') or 8
+        font_size = int(self._pm.get_value(self.canvas, 'font_size') or 8)
 
         if getattr(self.canvas, 'crosshair_per_plot', False):
             for p in plots:


### PR DESCRIPTION
Crosshair labels were created with the default font size (8pt) and
never picked up the canvas-level setting, while ticks, captions,
grid spacing and units all did. On high-DPI screens this left the
crosshair illegible.

The cursor is already destroyed and rebuilt whenever the canvas is
reprocessed, so passing the property-manager value at construction
time is enough to pick up preference changes on the next activation.
Same pattern already used for the rest of the text elements, on
both matplotlib and pyqtgraph backends.