### PR TITLE
Add mini-map support while zooming (#100)

### DIFF
--- a/iplotlib/core/canvas.py
+++ b/iplotlib/core/canvas.py
@@ -365,6 +365,17 @@ class Canvas(ABC):
     def get_minimap_baseline(self):
         return self._minimap_baseline_x_range
 
+    def invalidate_minimap_snapshots(self) -> None:
+        for columns in self.plots:
+            for plot in columns:
+                if not plot:
+                    continue
+                for signals in plot.signals.values():
+                    for signal in signals:
+                        clear = getattr(signal, 'clear_minimap_snapshot', None)
+                        if clear is not None:
+                            clear()
+
     def get_signals_as_csv(self):
         x = pd.DataFrame()
         focus_plot = self.focus_plot

--- a/iplotlib/core/canvas.py
+++ b/iplotlib/core/canvas.py
@@ -81,6 +81,8 @@ class Canvas(ABC):
         only one of the subplots
     auto_refresh : int
         Auto redraw canvas every X seconds
+    show_minimap : bool
+        Show a mini-map below the main plot. Only valid with a single visible plot.
     _type : str
         type of the canvas
     max_diff: int
@@ -115,6 +117,7 @@ class Canvas(ABC):
     shared_x_axis: bool = None
     full_mode_all_stack: bool = None
     auto_refresh: int = 0
+    show_minimap: bool = False
     undo_redo: bool = False
     max_diff: int = None
     _type: str = None
@@ -147,6 +150,7 @@ class Canvas(ABC):
         self._type = self.__class__.__module__ + '.' + self.__class__.__qualname__
         if self.plots is None:
             self.plots = [[] for _ in range(self.cols)]
+        self._minimap_baseline_x_range = None
 
     def add_plot(self, plot, col=0):
         """
@@ -238,6 +242,7 @@ class Canvas(ABC):
         self.full_mode_all_stack = Canvas.full_mode_all_stack
         self.focus_plot = Canvas.focus_plot
         self.max_diff = Canvas.max_diff
+        self.show_minimap = Canvas.show_minimap
 
         for _, col in enumerate(self.plots):
             for _, plot in enumerate(col):
@@ -289,6 +294,7 @@ class Canvas(ABC):
         self.full_mode_all_stack = old_canvas['full_mode_all_stack']
         self.focus_plot = old_canvas['focus_plot']
         self.max_diff = old_canvas['max_diff']
+        self.show_minimap = old_canvas.get('show_minimap', False)
 
         for idxColumn, columns in enumerate(self.plots):
             for idxPlot, plot in enumerate(columns):
@@ -335,6 +341,29 @@ class Canvas(ABC):
                             key = compute_signal_uniqkey(signal)
                             if key in map_old_signals:
                                 signal.merge(map_old_signals[key])
+
+    def is_minimap_eligible(self) -> bool:
+        target = self.get_minimap_target_plot()
+        if target is None:
+            return False
+        return isinstance(target, PlotXY) and not isinstance(target, PlotXYWithSlider)
+
+    def get_minimap_target_plot(self):
+        if self.focus_plot is not None:
+            return self.focus_plot
+        visible = [p for col in self.plots for p in col if p is not None]
+        if len(visible) != 1:
+            return None
+        return visible[0]
+
+    def snapshot_minimap_baseline(self, x_min, x_max) -> None:
+        if x_min is None or x_max is None:
+            self._minimap_baseline_x_range = None
+            return
+        self._minimap_baseline_x_range = (x_min, x_max)
+
+    def get_minimap_baseline(self):
+        return self._minimap_baseline_x_range
 
     def get_signals_as_csv(self):
         x = pd.DataFrame()

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -189,9 +189,10 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                         continue
                     color = sig.color or '#1976d2'
                     ax.plot(x_data, y_data, linewidth=0.7, color=color)
-            ax.set_xlim(baseline[0], baseline[1])
             ax.relim()
             ax.autoscale_view(scalex=False, scaley=True)
+            ax.set_xlim(baseline[0], baseline[1], auto=False)
+            ax.set_autoscalex_on(False)
             ax.tick_params(axis='x', labelsize=7)
             ax.tick_params(axis='y', labelsize=7)
             ax.set_facecolor('#f5f5f5')

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -10,24 +10,28 @@
 #               -Introduce distance calculator. [Jaswant Sai Panchumarti]
 #               -Refactor and let superclass methods refresh, reset use set_canvas, get_canvas [Jaswant Sai Panchumarti]
 #   May 2022:   -Port to PySide6 and use new backend_qtagg from matplotlib[Leon Kos]
+import functools
 import typing
 from collections.abc import Collection
 
 import numpy as np
 from PySide6.QtCore import QMargins, Qt, Slot, Signal
 from PySide6.QtGui import QKeyEvent
-from PySide6.QtWidgets import QMessageBox, QSizePolicy, QVBoxLayout, QMenu
+from PySide6.QtWidgets import QMessageBox, QSizePolicy, QSplitter, QVBoxLayout, QMenu
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes as MPLAxes
 from matplotlib.backend_bases import _Mode, DrawEvent, Event, MouseButton, MouseEvent
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
 
 from iplotlib.core import PlotContour, SignalXY, PlotXY, PlotXYWithSlider, PlotContourWithSlider
 from iplotlib.core.canvas import Canvas
 from iplotlib.core.distance import DistanceCalculator
 from iplotlib.impl.matplotlib.matplotlibCanvas import MatplotlibParser
+from iplotlib.impl.matplotlib.dateFormatter import NanosecondDateFormatter
 from iplotlib.qt.gui.iplotQtCanvas import IplotQtCanvas
 from iplotlib.qt.gui.iplotSignalShiftDialog import SignalShiftDialog
 import iplotLogging.setupLogger as Sl
@@ -54,10 +58,31 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         self._mpl_toolbar = NavigationToolbar(self._mpl_renderer, self)
         self._mpl_toolbar.setVisible(False)
 
+        self._minimap_figure = Figure()
+        self._minimap_renderer = FigureCanvas(self._minimap_figure)
+        self._minimap_renderer.setParent(self)
+        self._minimap_renderer.setSizePolicy(self._mpl_size_pol)
+        self._minimap_renderer.setMinimumHeight(110)
+        self._minimap_renderer.setVisible(False)
+        self._minimap_axes = None
+        self._minimap_viewport_patch = None
+        self._minimap_xlim_cid = None
+        self._minimap_ylim_cid = None
+        self._minimap_connected_main_ax = None
+        self._minimap_signature = None
+
+        self._splitter = QSplitter(Qt.Orientation.Vertical, self)
+        self._splitter.setContentsMargins(QMargins())
+        self._splitter.setChildrenCollapsible(False)
+        self._splitter.addWidget(self._mpl_renderer)
+        self._splitter.addWidget(self._minimap_renderer)
+        self._splitter.setStretchFactor(0, 4)
+        self._splitter.setStretchFactor(1, 1)
+
         self._vlayout = QVBoxLayout(self)
         self._vlayout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self._vlayout.setContentsMargins(QMargins())
-        self._vlayout.addWidget(self._mpl_renderer)
+        self._vlayout.addWidget(self._splitter)
 
         # GUI event handlers
         self._mpl_renderer.mpl_connect('draw_event', self._mpl_draw_finish)
@@ -87,10 +112,130 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             self.set_mouse_mode(self._mmode or canvas.mouse_mode)
         else:
             self.render()
+            self._update_minimap()
             return
 
         self.render()
+        self._update_minimap()
         super().set_canvas(canvas)
+
+    def _get_main_axes_for_minimap(self):
+        canvas = self.get_canvas()
+        if canvas is None:
+            return None
+        target = canvas.get_minimap_target_plot()
+        if target is None:
+            return None
+        impl_list = self._parser._plot_impl_plot_lut.get(id(target))
+        if not impl_list:
+            return None
+        return impl_list[-1]
+
+    def _disconnect_minimap_xlim(self):
+        if self._minimap_connected_main_ax is not None:
+            for cid in (self._minimap_xlim_cid, self._minimap_ylim_cid):
+                if cid is None:
+                    continue
+                try:
+                    self._minimap_connected_main_ax.callbacks.disconnect(cid)
+                except Exception:
+                    pass
+        self._minimap_xlim_cid = None
+        self._minimap_ylim_cid = None
+        self._minimap_connected_main_ax = None
+
+    def _update_minimap(self):
+        canvas = self.get_canvas()
+        show = canvas is not None and canvas.show_minimap and canvas.is_minimap_eligible()
+        self._minimap_renderer.setVisible(show)
+        if show:
+            total = max(self._splitter.height(), 1)
+            minimap_h = max(int(total * 0.22), 110)
+            self._splitter.setSizes([total - minimap_h, minimap_h])
+        if not show:
+            self._disconnect_minimap_xlim()
+            self._minimap_figure.clear()
+            self._minimap_axes = None
+            self._minimap_viewport_patch = None
+            self._minimap_signature = None
+            self._minimap_renderer.draw_idle()
+            return
+
+        main_ax = self._get_main_axes_for_minimap()
+        if main_ax is None:
+            return
+
+        target_plot = canvas.get_minimap_target_plot()
+        baseline = canvas.get_minimap_baseline()
+        if baseline is None:
+            x_min, x_max = self._parser.get_oaw_axis_limits(main_ax, 0)
+            canvas.snapshot_minimap_baseline(x_min, x_max)
+            baseline = canvas.get_minimap_baseline()
+
+        signature = (id(target_plot), baseline)
+        if self._minimap_signature != signature or self._minimap_axes is None:
+            self._disconnect_minimap_xlim()
+            self._minimap_figure.clear()
+            ax = self._minimap_figure.add_subplot(111)
+            for signals in target_plot.signals.values():
+                for sig in signals:
+                    if not isinstance(sig, SignalXY):
+                        continue
+                    x_data = getattr(sig, 'x_data', None)
+                    y_data = getattr(sig, 'y_data', None)
+                    if x_data is None or y_data is None:
+                        continue
+                    if len(x_data) == 0 or len(y_data) == 0:
+                        continue
+                    color = sig.color or '#1976d2'
+                    ax.plot(x_data, y_data, linewidth=0.7, color=color)
+            ax.set_xlim(baseline[0], baseline[1])
+            ax.relim()
+            ax.autoscale_view(scalex=False, scaley=True)
+            ax.tick_params(axis='x', labelsize=7)
+            ax.tick_params(axis='y', labelsize=7)
+            ax.set_facecolor('#f5f5f5')
+            main_x_formatter = main_ax.xaxis.get_major_formatter()
+            if isinstance(main_x_formatter, NanosecondDateFormatter):
+                clone = NanosecondDateFormatter(
+                    ax_idx=0,
+                    label_segments=main_x_formatter.label_segments,
+                    postfix_end=main_x_formatter.postfix_end,
+                    postfix_start=main_x_formatter.postfix_start,
+                    offset_lut=None,
+                    roundh=main_x_formatter._round,
+                )
+                ax.xaxis.set_major_formatter(clone)
+
+            rect = Rectangle((baseline[0], 0), baseline[1] - baseline[0], 1,
+                             facecolor='#ffb300', edgecolor='#e65100',
+                             alpha=0.5, linewidth=2.0, zorder=10,
+                             transform=ax.get_xaxis_transform(), clip_on=False)
+            ax.add_patch(rect)
+            self._minimap_viewport_patch = rect
+            self._minimap_axes = ax
+            self._minimap_figure.tight_layout()
+            self._minimap_signature = signature
+
+        update_rect = functools.partial(self._viewlims_update_rect, self._minimap_viewport_patch)
+        self._minimap_xlim_cid = main_ax.callbacks.connect('xlim_changed', update_rect)
+        self._minimap_ylim_cid = main_ax.callbacks.connect('ylim_changed', update_rect)
+        self._minimap_connected_main_ax = main_ax
+        update_rect(main_ax)
+
+    def _viewlims_update_rect(self, rect, ax):
+        x_lo, x_hi = self._parser.get_oaw_axis_limits(ax, 0)
+        if x_lo is None or x_hi is None:
+            return
+        canvas = self.get_canvas()
+        baseline = canvas.get_minimap_baseline() if canvas is not None else None
+        if baseline is not None:
+            full_span = baseline[1] - baseline[0]
+            shows_full = full_span > 0 and abs(x_lo - baseline[0]) < full_span * 1e-6 and abs(x_hi - baseline[1]) < full_span * 1e-6
+            rect.set_visible(not shows_full)
+        rect.set_x(x_lo)
+        rect.set_width(x_hi - x_lo)
+        self._minimap_renderer.draw_idle()
 
     def _is_signal_visible(self, signal) -> bool:
         """Check if signal is visible (Matplotlib implementation)."""
@@ -301,13 +446,21 @@ class QtMatplotlibCanvas(IplotQtCanvas):
 
     def _full_screen_mode_on(self, impl_plot):
         self._parser.set_focus_plot(impl_plot)
+        canvas = self.get_canvas()
+        if canvas is not None:
+            canvas.snapshot_minimap_baseline(None, None)
         self.refresh()
         self.stats(self.get_canvas())
+        self.focusChanged.emit()
 
     def _full_screen_mode_off(self):
         self._parser.set_focus_plot(None)
+        canvas = self.get_canvas()
+        if canvas is not None:
+            canvas.snapshot_minimap_baseline(None, None)
         self.refresh()
         self.stats(self.get_canvas())
+        self.focusChanged.emit()
 
     def _create_drag_preview(self, dy_offset, dx_offset=0.0):
         """Create/update preview line during drag for Matplotlib."""

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -196,6 +196,8 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                     if (getattr(sig, 'envelope', False) and y_max is not None
                             and y_avg is not None and len(y_max) == len(x_data)
                             and len(y_avg) == len(x_data)):
+                        ax.plot(x_data, y_data, linewidth=0, color=color)
+                        ax.plot(x_data, y_max, linewidth=0, color=color)
                         ax.fill_between(x_data, y_data, y_max, alpha=0.3, color=color, linewidth=0)
                         ax.plot(x_data, y_avg, linewidth=0.7, color=color)
                     else:

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -191,7 +191,15 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                     if len(x_data) == 0 or len(y_data) == 0:
                         continue
                     color = sig.color or '#1976d2'
-                    ax.plot(x_data, y_data, linewidth=0.7, color=color)
+                    y_max = getattr(sig, '_minimap_y_max_data', None)
+                    y_avg = getattr(sig, '_minimap_y_avg_data', None)
+                    if (getattr(sig, 'envelope', False) and y_max is not None
+                            and y_avg is not None and len(y_max) == len(x_data)
+                            and len(y_avg) == len(x_data)):
+                        ax.fill_between(x_data, y_data, y_max, alpha=0.3, color=color, linewidth=0)
+                        ax.plot(x_data, y_avg, linewidth=0.7, color=color)
+                    else:
+                        ax.plot(x_data, y_data, linewidth=0.7, color=color)
             ax.relim()
             ax.autoscale_view(scalex=False, scaley=True)
             ax.set_xlim(baseline[0], baseline[1], auto=False)

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -198,7 +198,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                             and len(y_avg) == len(x_data)):
                         ax.plot(x_data, y_data, linewidth=0, color=color)
                         ax.plot(x_data, y_max, linewidth=0, color=color)
-                        ax.fill_between(x_data, y_data, y_max, alpha=0.3, color=color, linewidth=0)
+                        ax.fill_between(x_data, y_data, y_max, alpha=0.6, color=color, linewidth=0)
                         ax.plot(x_data, y_avg, linewidth=0.7, color=color)
                     else:
                         ax.plot(x_data, y_data, linewidth=0.7, color=color)

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -181,8 +181,11 @@ class QtMatplotlibCanvas(IplotQtCanvas):
                 for sig in signals:
                     if not isinstance(sig, SignalXY):
                         continue
-                    x_data = getattr(sig, 'x_data', None)
-                    y_data = getattr(sig, 'y_data', None)
+                    x_data = getattr(sig, '_minimap_x_data', None)
+                    y_data = getattr(sig, '_minimap_y_data', None)
+                    if x_data is None or len(x_data) == 0:
+                        x_data = getattr(sig, 'x_data', None)
+                        y_data = getattr(sig, 'y_data', None)
                     if x_data is None or y_data is None:
                         continue
                     if len(x_data) == 0 or len(y_data) == 0:

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -217,11 +217,13 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             self._minimap_figure.tight_layout()
             self._minimap_signature = signature
 
-        update_rect = functools.partial(self._viewlims_update_rect, self._minimap_viewport_patch)
-        self._minimap_xlim_cid = main_ax.callbacks.connect('xlim_changed', update_rect)
-        self._minimap_ylim_cid = main_ax.callbacks.connect('ylim_changed', update_rect)
-        self._minimap_connected_main_ax = main_ax
-        update_rect(main_ax)
+        if self._minimap_connected_main_ax is not main_ax:
+            self._disconnect_minimap_xlim()
+            update_rect = functools.partial(self._viewlims_update_rect, self._minimap_viewport_patch)
+            self._minimap_xlim_cid = main_ax.callbacks.connect('xlim_changed', update_rect)
+            self._minimap_ylim_cid = main_ax.callbacks.connect('ylim_changed', update_rect)
+            self._minimap_connected_main_ax = main_ax
+        self._viewlims_update_rect(self._minimap_viewport_patch, main_ax)
 
     def _viewlims_update_rect(self, rect, ax):
         x_lo, x_hi = self._parser.get_oaw_axis_limits(ax, 0)

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -473,7 +473,7 @@ class PyQtGraphParser(BackendParserBase):
             # 1. Configure and add the image first, before any children
             # Set rectangle view for the image. Values correspond to: x, y, w, h
             # Transformations needed to convert pixels into real data values
-            img.setRect(QtCore.QRectF(x_min, y_min, float(np.ptp(x_data)), float(np.ptp(y_data))))
+            img.setRect(QtCore.QRectF(x_min, y_min, x_max - x_min, y_max - y_min))
 
             tr = QTransform()
             tr.translate(x_min, y_min)

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -473,7 +473,7 @@ class PyQtGraphParser(BackendParserBase):
             # 1. Configure and add the image first, before any children
             # Set rectangle view for the image. Values correspond to: x, y, w, h
             # Transformations needed to convert pixels into real data values
-            img.setRect(QtCore.QRectF(x_min, y_min, np.ptp(x_data), np.ptp(y_data)))
+            img.setRect(QtCore.QRectF(x_min, y_min, float(np.ptp(x_data)), float(np.ptp(y_data))))
 
             tr = QTransform()
             tr.translate(x_min, y_min)

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -175,8 +175,21 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                     continue
                 if len(x_data) == 0 or len(y_data) == 0:
                     continue
-                pen = pg.mkPen(sig.color or '#1976d2', width=1)
-                self._minimap_plot.plot(x_data, y_data, pen=pen)
+                color = sig.color or '#1976d2'
+                pen = pg.mkPen(color, width=1)
+                y_max = getattr(sig, '_minimap_y_max_data', None)
+                y_avg = getattr(sig, '_minimap_y_avg_data', None)
+                if (getattr(sig, 'envelope', False) and y_max is not None
+                        and y_avg is not None and len(y_max) == len(x_data)
+                        and len(y_avg) == len(x_data)):
+                    c_min = self._minimap_plot.plot(x_data, y_data, pen=pg.mkPen(color, width=0))
+                    c_max = self._minimap_plot.plot(x_data, y_max, pen=pg.mkPen(color, width=0))
+                    qcolor = pg.mkColor(color)
+                    qcolor.setAlphaF(0.3)
+                    self._minimap_plot.addItem(pg.FillBetweenItem(c_min, c_max, brush=pg.mkBrush(qcolor)))
+                    self._minimap_plot.plot(x_data, y_avg, pen=pen)
+                else:
+                    self._minimap_plot.plot(x_data, y_data, pen=pen)
         self._minimap_plot.getViewBox().setLimits(xMin=baseline[0], xMax=baseline[1])
         self._minimap_plot.setXRange(baseline[0], baseline[1], padding=0)
         self._minimap_plot.getViewBox().disableAutoRange(axis=pg.ViewBox.XAxis)

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -174,7 +174,9 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                     continue
                 pen = pg.mkPen(sig.color or '#1976d2', width=1)
                 self._minimap_plot.plot(x_data, y_data, pen=pen)
+        self._minimap_plot.getViewBox().setLimits(xMin=baseline[0], xMax=baseline[1])
         self._minimap_plot.setXRange(baseline[0], baseline[1], padding=0)
+        self._minimap_plot.getViewBox().disableAutoRange(axis=pg.ViewBox.XAxis)
 
         region = pg.LinearRegionItem(values=[cur_min, cur_max], movable=False,
                                      brush=pg.mkBrush(255, 179, 0, 120),

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -1,12 +1,13 @@
 import os
 
-from PySide6.QtCore import QMargins, Qt, Signal, QEvent
-from PySide6.QtWidgets import QVBoxLayout, QMenu, QMessageBox
+from PySide6.QtCore import QMargins, Qt, Signal, QEvent, QTimer
+from PySide6.QtWidgets import QVBoxLayout, QMenu, QMessageBox, QSplitter
 
 import numpy as np
 from iplotlib.core import Canvas, PlotXY, PlotContour, SignalXY, PlotContourWithSlider
 from iplotlib.core.distance import DistanceCalculator
 from iplotlib.impl.pyqtgraph.pyQtGraphCanvas import PyQtGraphParser
+from iplotlib.impl.pyqtgraph.dateFormatter import NanosecondDateFormatter
 from iplotlib.qt.gui.iplotQtCanvas import IplotQtCanvas
 from iplotlib.qt.gui.iplotSignalShiftDialog import SignalShiftDialog
 import iplotLogging.setupLogger as Sl
@@ -33,10 +34,33 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         # Track connected ViewBoxes to avoid duplicate connections
         self._connected_viewboxes = set()
 
+        self._minimap_widget = pg.GraphicsLayoutWidget()
+        self._minimap_widget.setMinimumHeight(110)
+        self._minimap_widget.setVisible(False)
+        self._minimap_widget.setBackground('#f5f5f5')
+        self._minimap_plot = self._minimap_widget.addPlot(row=0, col=0)
+        self._minimap_plot.setMouseEnabled(x=False, y=False)
+        self._minimap_plot.showAxis('left')
+        self._minimap_plot.showAxis('bottom')
+        self._minimap_plot.setMenuEnabled(False)
+        self._minimap_plot.hideButtons()
+        self._minimap_common_label = None
+        self._minimap_viewport_item = None
+        self._minimap_connected_main_vb = None
+        self._minimap_signature = None
+
+        self._splitter = QSplitter(Qt.Orientation.Vertical, self)
+        self._splitter.setContentsMargins(QMargins())
+        self._splitter.setChildrenCollapsible(False)
+        self._splitter.addWidget(self._parser.figure)
+        self._splitter.addWidget(self._minimap_widget)
+        self._splitter.setStretchFactor(0, 4)
+        self._splitter.setStretchFactor(1, 1)
+
         self._vlayout = QVBoxLayout(self)
         self._vlayout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self._vlayout.setContentsMargins(QMargins())
-        self._vlayout.addWidget(self._parser.figure)
+        self._vlayout.addWidget(self._splitter)
 
         self.setLayout(self._vlayout)
         self.set_canvas(kwargs.get('canvas'))
@@ -71,6 +95,137 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                     self._connected_viewboxes.add(vb_id)
 
         super().set_canvas(canvas)
+        self._update_minimap()
+
+    def _get_main_plot_for_minimap(self) -> PlotItem:
+        canvas = self.get_canvas()
+        if canvas is None:
+            return None
+        target = canvas.get_minimap_target_plot()
+        if target is None:
+            return None
+        impl_list = self._parser._plot_impl_plot_lut.get(id(target))
+        if impl_list:
+            return impl_list[-1]
+        for stack in self._parser._layout_stacks.values():
+            for plot in stack.values():
+                return plot
+        return None
+
+    def _update_minimap(self):
+        canvas = self.get_canvas()
+        show = canvas is not None and canvas.show_minimap and canvas.is_minimap_eligible()
+        self._minimap_widget.setVisible(show)
+        if show:
+            total = max(self._splitter.height(), 1)
+            minimap_h = max(int(total * 0.22), 110)
+            self._splitter.setSizes([total - minimap_h, minimap_h])
+        if not show:
+            self._minimap_plot.clear()
+            self._minimap_viewport_item = None
+            self._minimap_signature = None
+            self._disconnect_minimap_signals()
+            return
+
+        main_plot = self._get_main_plot_for_minimap()
+        if main_plot is None:
+            QTimer.singleShot(0, self._update_minimap)
+            return
+
+        target_plot = canvas.get_minimap_target_plot()
+        baseline = canvas.get_minimap_baseline()
+        cur_min, cur_max = self._parser.get_oaw_axis_limits(main_plot, 0)
+        if cur_min is None or cur_max is None:
+            return
+        if baseline is None:
+            canvas.snapshot_minimap_baseline(cur_min, cur_max)
+            baseline = canvas.get_minimap_baseline()
+
+        signature = (id(target_plot), baseline)
+        if self._minimap_signature == signature and self._minimap_viewport_item is not None:
+            self._minimap_viewport_item.setRegion((cur_min, cur_max))
+            self._connect_minimap_signals(main_plot)
+            return
+
+        self._minimap_plot.clear()
+        self._minimap_viewport_item = None
+        is_date_axis = bool(target_plot.axes and getattr(target_plot.axes[0], 'is_date', False))
+        bottom_axis = self._minimap_plot.getAxis('bottom')
+        if not isinstance(bottom_axis, NanosecondDateFormatter) or getattr(bottom_axis, 'is_date', None) != is_date_axis:
+            new_bottom = NanosecondDateFormatter(is_date=is_date_axis, orientation='bottom')
+            self._minimap_plot.setAxisItems({'bottom': new_bottom})
+            if self._minimap_common_label is not None:
+                try:
+                    self._minimap_widget.ci.removeItem(self._minimap_common_label)
+                except Exception:
+                    pass
+            self._minimap_widget.ci.addItem(new_bottom.common_label, row=1, col=0)
+            new_bottom.common_label.setMaximumHeight(14)
+            self._minimap_common_label = new_bottom.common_label
+        for signals in target_plot.signals.values():
+            for sig in signals:
+                if not isinstance(sig, SignalXY):
+                    continue
+                x_data = getattr(sig, 'x_data', None)
+                y_data = getattr(sig, 'y_data', None)
+                if x_data is None or y_data is None:
+                    continue
+                if len(x_data) == 0 or len(y_data) == 0:
+                    continue
+                pen = pg.mkPen(sig.color or '#1976d2', width=1)
+                self._minimap_plot.plot(x_data, y_data, pen=pen)
+        self._minimap_plot.setXRange(baseline[0], baseline[1], padding=0)
+
+        region = pg.LinearRegionItem(values=[cur_min, cur_max], movable=False,
+                                     brush=pg.mkBrush(255, 179, 0, 120),
+                                     pen=pg.mkPen('#e65100', width=2))
+        region.setZValue(10)
+        self._minimap_plot.addItem(region, ignoreBounds=True)
+        self._minimap_viewport_item = region
+        self._minimap_signature = signature
+        full_span = baseline[1] - baseline[0]
+        shows_full = full_span > 0 and abs(cur_min - baseline[0]) < full_span * 1e-6 and abs(cur_max - baseline[1]) < full_span * 1e-6
+        region.setVisible(not shows_full)
+
+        self._connect_minimap_signals(main_plot)
+
+    def _connect_minimap_signals(self, main_plot):
+        if self._minimap_connected_main_vb is main_plot:
+            return
+        self._disconnect_minimap_signals()
+        main_plot.sigRangeChanged.connect(self._on_main_x_range_changed)
+        self._minimap_connected_main_vb = main_plot
+
+    def _disconnect_minimap_signals(self):
+        if self._minimap_connected_main_vb is not None:
+            try:
+                self._minimap_connected_main_vb.sigRangeChanged.disconnect(self._on_main_x_range_changed)
+            except Exception:
+                pass
+            self._minimap_connected_main_vb = None
+
+    def _on_main_x_range_changed(self, window, view_range):
+        if self._minimap_viewport_item is None:
+            return
+        main_plot = self._get_main_plot_for_minimap()
+        if main_plot is None:
+            return
+        x_lo, x_hi = self._parser.get_oaw_axis_limits(main_plot, 0)
+        if x_lo is None or x_hi is None:
+            return
+        canvas = self.get_canvas()
+        baseline = canvas.get_minimap_baseline() if canvas is not None else None
+        if baseline is not None:
+            full_span = baseline[1] - baseline[0]
+            shows_full = full_span > 0 and abs(x_lo - baseline[0]) < full_span * 1e-6 and abs(x_hi - baseline[1]) < full_span * 1e-6
+            self._minimap_viewport_item.setVisible(not shows_full)
+        self._minimap_viewport_item.setRegion((x_lo, x_hi))
+
+    def _sync_minimap_viewport(self):
+        main_plot = self._get_main_plot_for_minimap()
+        if main_plot is None or self._minimap_viewport_item is None:
+            return
+        self._on_main_x_range_changed(main_plot, main_plot.getViewBox().viewRange())
 
     def get_base_plot(self) -> PlotItem:
         for stack in self._parser._layout_stacks.values():
@@ -267,13 +422,21 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
 
     def _full_screen_mode_on(self, impl_plot):
         self._parser.set_focus_plot(impl_plot)
+        canvas = self.get_canvas()
+        if canvas is not None:
+            canvas.snapshot_minimap_baseline(None, None)
         self.refresh()
         self.stats(self.get_canvas())
+        self.focusChanged.emit()
 
     def _full_screen_mode_off(self):
         self._parser.set_focus_plot(None)
+        canvas = self.get_canvas()
+        if canvas is not None:
+            canvas.snapshot_minimap_baseline(None, None)
         self.refresh()
         self.stats(self.get_canvas())
+        self.focusChanged.emit()
 
     def _impl_mouse_press_handler(self, view_box, event):
         """Handle mouse press events in PyQtGraph."""
@@ -427,6 +590,7 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
                 self.push_view_lim_cmd()
             # Update statistics
             self.stats(self.get_canvas())
+            self._sync_minimap_viewport()
 
         is_double = callable(getattr(event, 'double', None)) and event.double()
         if event is not None and event.button() == Qt.MouseButton.RightButton and not is_double:

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -166,8 +166,11 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
             for sig in signals:
                 if not isinstance(sig, SignalXY):
                     continue
-                x_data = getattr(sig, 'x_data', None)
-                y_data = getattr(sig, 'y_data', None)
+                x_data = getattr(sig, '_minimap_x_data', None)
+                y_data = getattr(sig, '_minimap_y_data', None)
+                if x_data is None or len(x_data) == 0:
+                    x_data = getattr(sig, 'x_data', None)
+                    y_data = getattr(sig, 'y_data', None)
                 if x_data is None or y_data is None:
                     continue
                 if len(x_data) == 0 or len(y_data) == 0:

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -145,6 +145,10 @@ class IplotSignalAdapter(ProcessingSignal):
         self.x_data = BufferObject()
         self.y_data = BufferObject()
         self.z_data = BufferObject()
+        # Full-range snapshot used by the minimap. Captured the first time
+        # data is finalised for this signal and invalidated by clear_minimap_snapshot().
+        self._minimap_x_data = None
+        self._minimap_y_data = None
 
         # 2. Post-initialize ArraySignal's properties and our name.
         self._init_label()
@@ -502,7 +506,22 @@ class IplotSignalAdapter(ProcessingSignal):
         self.z_data = self.truncate_to_target(self.z_data, self.x_data,
                                               source_label='z', target_label='x')
 
+        # 4. Capture full-range snapshot for the minimap the first time
+        # data is populated. Cleared by clear_minimap_snapshot() at Draw / import.
+        if self._minimap_x_data is None and len(self.x_data) > 0:
+            self._minimap_x_data = self.x_data.copy()
+            self._minimap_y_data = self.y_data.copy()
+
         self._report_xyz_data()
+
+    def clear_minimap_snapshot(self):
+        """Drop the cached full-range data used by the minimap.
+
+        Call this whenever the requested time/pulse range changes so that the
+        next data load populates a fresh snapshot.
+        """
+        self._minimap_x_data = None
+        self._minimap_y_data = None
 
     def _process_data(self):
         # 1. Cannot process data when _fetch_data failed or did not occur

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -145,8 +145,7 @@ class IplotSignalAdapter(ProcessingSignal):
         self.x_data = BufferObject()
         self.y_data = BufferObject()
         self.z_data = BufferObject()
-        # Full-range snapshot used by the minimap. Captured the first time
-        # data is finalised for this signal and invalidated by clear_minimap_snapshot().
+        # Full-range minimap snapshot; invalidated by clear_minimap_snapshot().
         self._minimap_x_data = None
         self._minimap_y_data = None
         self._minimap_y_max_data = None
@@ -508,15 +507,13 @@ class IplotSignalAdapter(ProcessingSignal):
         self.z_data = self.truncate_to_target(self.z_data, self.x_data,
                                               source_label='z', target_label='x')
 
-        # 3b. Align envelope avg buffer (data_store[3]) to x_data so the
-        # minimap snapshot guard below accepts it.
+        # 3b. Align envelope avg buffer to x_data for the minimap snapshot guard below.
         if getattr(self, 'envelope', False) and len(self.data_store) >= 4:
             self.data_store[3] = self.truncate_to_target(
                 self.data_store[3], self.x_data,
                 source_label='avg', target_label='x')
 
-        # 4. Capture full-range snapshot for the minimap the first time
-        # data is populated. Cleared by clear_minimap_snapshot() at Draw / import.
+        # 4. Capture the full-range minimap snapshot on first populate.
         if self._minimap_x_data is None and len(self.x_data) > 0:
             self._minimap_x_data = self.x_data.copy()
             self._minimap_y_data = self.y_data.copy()
@@ -529,11 +526,7 @@ class IplotSignalAdapter(ProcessingSignal):
         self._report_xyz_data()
 
     def clear_minimap_snapshot(self):
-        """Drop the cached full-range data used by the minimap.
-
-        Call this whenever the requested time/pulse range changes so that the
-        next data load populates a fresh snapshot.
-        """
+        """Drop the cached full-range minimap data so the next load repopulates it."""
         self._minimap_x_data = None
         self._minimap_y_data = None
         self._minimap_y_max_data = None

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -508,6 +508,13 @@ class IplotSignalAdapter(ProcessingSignal):
         self.z_data = self.truncate_to_target(self.z_data, self.x_data,
                                               source_label='z', target_label='x')
 
+        # 3b. Align envelope avg buffer (data_store[3]) to x_data so the
+        # minimap snapshot guard below accepts it.
+        if getattr(self, 'envelope', False) and len(self.data_store) >= 4:
+            self.data_store[3] = self.truncate_to_target(
+                self.data_store[3], self.x_data,
+                source_label='avg', target_label='x')
+
         # 4. Capture full-range snapshot for the minimap the first time
         # data is populated. Cleared by clear_minimap_snapshot() at Draw / import.
         if self._minimap_x_data is None and len(self.x_data) > 0:

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -149,6 +149,8 @@ class IplotSignalAdapter(ProcessingSignal):
         # data is finalised for this signal and invalidated by clear_minimap_snapshot().
         self._minimap_x_data = None
         self._minimap_y_data = None
+        self._minimap_y_max_data = None
+        self._minimap_y_avg_data = None
 
         # 2. Post-initialize ArraySignal's properties and our name.
         self._init_label()
@@ -511,6 +513,11 @@ class IplotSignalAdapter(ProcessingSignal):
         if self._minimap_x_data is None and len(self.x_data) > 0:
             self._minimap_x_data = self.x_data.copy()
             self._minimap_y_data = self.y_data.copy()
+            if (getattr(self, 'envelope', False) and len(self.data_store) >= 4
+                    and len(self.z_data) == len(self.x_data)
+                    and len(self.data_store[3]) == len(self.x_data)):
+                self._minimap_y_max_data = self.z_data.copy()
+                self._minimap_y_avg_data = self.data_store[3].copy()
 
         self._report_xyz_data()
 
@@ -522,6 +529,8 @@ class IplotSignalAdapter(ProcessingSignal):
         """
         self._minimap_x_data = None
         self._minimap_y_data = None
+        self._minimap_y_max_data = None
+        self._minimap_y_avg_data = None
 
     def _process_data(self):
         # 1. Cannot process data when _fetch_data failed or did not occur

--- a/iplotlib/qt/gui/iplotCanvasToolbar.py
+++ b/iplotlib/qt/gui/iplotCanvasToolbar.py
@@ -58,6 +58,12 @@ class IplotQtCanvasToolbar(QToolBar):
         # Statistics
         self.statistics = QAction(create_icon('stats_icon'), 'Statistics', self)
         self.addAction(self.statistics)
+
+        self.minimapAction = QAction(create_icon('minimap', 'svg'), 'Mini-map', self)
+        self.minimapAction.setCheckable(True)
+        self.minimapAction.setEnabled(False)
+        self.minimapAction.setToolTip('Show mini-map (available when a single plot is visible)')
+        self.addAction(self.minimapAction)
         self.addSeparator()
 
         # Command-history management

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -30,6 +30,7 @@ class IplotQtCanvas(QWidget):
     Base class for all Qt related canvas implementations
     """
     cmdDone = Signal(IplotCommand)
+    focusChanged = Signal()
     openPlotPreferences = Signal(object)
     signalShiftRequested = Signal(str, str, str, str, float, float, bool)
     # Unified shift signals (work for both drag and DIST)
@@ -86,6 +87,23 @@ class IplotQtCanvas(QWidget):
         else:
             self._stats_table.raise_()
             self._stats_table.activateWindow()
+
+    def set_minimap(self, on: bool) -> None:
+        if self._parser is None:
+            return
+        canvas = self.get_canvas()
+        if canvas is None:
+            return
+        canvas.show_minimap = bool(on)
+        if not on:
+            canvas.snapshot_minimap_baseline(None, None)
+        else:
+            target = canvas.get_minimap_target_plot()
+            if target is not None and target.axes:
+                axis = target.axes[0]
+                canvas.snapshot_minimap_baseline(axis.original_begin, axis.original_end)
+        with self.view_retainer():
+            self.refresh()
 
     def drop_history(self):
         """history: clear undo history. after this, can no longer undo"""

--- a/iplotlib/qt/gui/iplotQtMainWindow.py
+++ b/iplotlib/qt/gui/iplotQtMainWindow.py
@@ -308,7 +308,6 @@ class IplotQtMainWindow(QMainWindow):
         for i in range(self.canvasStack.count()):
             self.check_history(self.canvasStack.widget(i))
         self.refresh_minimap_availability()
-        super().showEvent(event)
 
     def closeEvent(self, event: QCloseEvent):
         """

--- a/iplotlib/qt/gui/iplotQtMainWindow.py
+++ b/iplotlib/qt/gui/iplotQtMainWindow.py
@@ -67,11 +67,13 @@ class IplotQtMainWindow(QMainWindow):
         self.toolBar.undoAction.triggered.connect(self.undo)
         self.toolBar.redoAction.triggered.connect(self.redo)
         self.toolBar.statistics.triggered.connect(self.show_stats)
+        self.toolBar.minimapAction.toggled.connect(self.on_minimap_toggled)
         self.toolBar.toolActivated.connect(
             lambda tool_name:
             [self.canvasStack.widget(i).set_mouse_mode(tool_name) for i in range(self.canvasStack.count())])
         self.canvasStack.canvasAdded.connect(self.on_canvas_add)
         self.canvasStack.currentChanged.connect(lambda idx: self.check_history(self.canvasStack.widget(idx)))
+        self.canvasStack.currentChanged.connect(lambda _: self.refresh_minimap_availability())
         self.toolBar.saveImageAction.triggered.connect(self.save_canvas_image)
         self.toolBar.redrawAction.triggered.connect(self.re_draw)
         self.toolBar.detachAction.triggered.connect(self.detach)
@@ -108,6 +110,29 @@ class IplotQtMainWindow(QMainWindow):
         if not w:
             return
         w.show_stats()
+
+    def on_minimap_toggled(self, checked: bool):
+        w = self.canvasStack.currentWidget()
+        if not w:
+            return
+        w.set_minimap(checked)
+
+    def refresh_minimap_availability(self):
+        w = self.canvasStack.currentWidget()
+        action = self.toolBar.minimapAction
+        if not w:
+            action.setEnabled(False)
+            return
+        canvas = w.get_canvas()
+        eligible = canvas is not None and canvas.is_minimap_eligible()
+        action.setEnabled(eligible)
+        desired = bool(eligible and canvas is not None and canvas.show_minimap)
+        if action.isChecked() != desired:
+            action.blockSignals(True)
+            action.setChecked(desired)
+            action.blockSignals(False)
+        if not eligible and canvas is not None and canvas.show_minimap:
+            w.set_minimap(False)
 
     def save_canvas_image(self):
         w = self.canvasStack.currentWidget()
@@ -156,6 +181,8 @@ class IplotQtMainWindow(QMainWindow):
         """
         w.cmdDone.connect(partial(self.on_cmd_done, w))
         w.openPlotPreferences.connect(self._open_plot_preferences)
+        w.focusChanged.connect(self.refresh_minimap_availability)
+        self.refresh_minimap_availability()
 
     def on_cmd_done(self, w: IplotQtCanvas, cmd: IplotCommand):
         """
@@ -165,6 +192,7 @@ class IplotQtMainWindow(QMainWindow):
         """
         self.check_history(w)
         self.toolBar.undoAction.setText(f"Undo {cmd.name}")
+        self.refresh_minimap_availability()
 
     def _open_plot_preferences(self, target):
         """Open preferences window and navigate to the given Plot or Signal in the tree.
@@ -223,6 +251,7 @@ class IplotQtMainWindow(QMainWindow):
                 w.refresh()
         self.prefWindow.set_canvas_from_preferences()
         self.prefWindow.post_applied()
+        self.refresh_minimap_availability()
 
     def reset_prefs(self):
         w = self.canvasStack.currentWidget()
@@ -278,6 +307,7 @@ class IplotQtMainWindow(QMainWindow):
         super().showEvent(event)
         for i in range(self.canvasStack.count()):
             self.check_history(self.canvasStack.widget(i))
+        self.refresh_minimap_availability()
         super().showEvent(event)
 
     def closeEvent(self, event: QCloseEvent):

--- a/iplotlib/qt/icons/minimap.svg
+++ b/iplotlib/qt/icons/minimap.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect x="3" y="5" width="18" height="14" rx="2" ry="2"
+        fill="none" stroke="#222" stroke-width="1.8"/>
+  <rect x="8" y="8" width="8" height="8" rx="0.5" ry="0.5"
+        fill="#ffb300" fill-opacity="0.5"
+        stroke="#e65100" stroke-width="1.6"/>
+</svg>

--- a/iplotlib/standalone/tests/test_main_window.py
+++ b/iplotlib/standalone/tests/test_main_window.py
@@ -222,5 +222,136 @@ class PreferencesWindowTest(unittest.TestCase):
             win.close()
 
 
+class MinimapStateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+
+    def test_default_state_is_off(self):
+        c = Canvas(1, 1)
+        self.assertFalse(c.show_minimap)
+        self.assertIsNone(c.get_minimap_baseline())
+
+    def test_eligibility_single_plot(self):
+        c = _canvas_with_signal()
+        self.assertTrue(c.is_minimap_eligible())
+        self.assertIsNotNone(c.get_minimap_target_plot())
+
+    def test_eligibility_multiple_plots(self):
+        c = Canvas(2, 1)
+        for _ in range(2):
+            p = PlotXY()
+            sig = SignalXY(label='s')
+            sig.set_data([np.linspace(0, 1, 10), np.zeros(10)])
+            p.add_signal(sig)
+            c.add_plot(p, 0)
+        self.assertFalse(c.is_minimap_eligible())
+
+    def test_eligibility_with_focus_plot(self):
+        c = Canvas(2, 1)
+        for _ in range(2):
+            p = PlotXY()
+            sig = SignalXY(label='s')
+            sig.set_data([np.linspace(0, 1, 10), np.zeros(10)])
+            p.add_signal(sig)
+            c.add_plot(p, 0)
+        c.focus_plot = c.plots[0][0]
+        self.assertTrue(c.is_minimap_eligible())
+
+    def test_eligibility_rejects_non_xy_plots(self):
+        from iplotlib.core.plot import PlotContour, PlotXYWithSlider
+        c = Canvas(1, 1)
+        c.add_plot(PlotContour(), 0)
+        self.assertFalse(c.is_minimap_eligible())
+
+        c2 = Canvas(1, 1)
+        c2.add_plot(PlotXYWithSlider(), 0)
+        self.assertFalse(c2.is_minimap_eligible())
+
+    def test_baseline_snapshot_roundtrip(self):
+        c = Canvas(1, 1)
+        c.snapshot_minimap_baseline(10, 20)
+        self.assertEqual(c.get_minimap_baseline(), (10, 20))
+        c.snapshot_minimap_baseline(None, None)
+        self.assertIsNone(c.get_minimap_baseline())
+
+    def test_show_minimap_serialization_roundtrip(self):
+        c = _canvas_with_signal()
+        c.show_minimap = True
+        d = c.to_dict()
+        self.assertTrue(d['show_minimap'])
+        restored = Canvas.from_dict(d)
+        self.assertTrue(restored.show_minimap)
+
+    def test_old_workspace_without_show_minimap_defaults_off(self):
+        c = _canvas_with_signal()
+        d = c.to_dict()
+        d.pop('show_minimap', None)
+        restored = Canvas.from_dict(d)
+        self.assertFalse(restored.show_minimap)
+
+
+class MinimapToolbarTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+
+    def _add_canvas(self, win, core=None):
+        qt_canvas = IplotQtCanvasFactory.new('matplotlib',
+                                             canvas=core or _canvas_with_signal())
+        qt_canvas.set_canvas(qt_canvas.get_canvas())
+        win.canvasStack.addWidget(qt_canvas)
+        self.app.processEvents()
+        return qt_canvas
+
+    def test_minimap_action_exists_and_disabled_by_default(self):
+        win = IplotQtMainWindow()
+        try:
+            self.assertIsNotNone(win.toolBar.minimapAction)
+            self.assertTrue(win.toolBar.minimapAction.isCheckable())
+            self.assertFalse(win.toolBar.minimapAction.isEnabled())
+        finally:
+            win.close()
+
+    def test_minimap_action_enabled_for_single_plot_canvas(self):
+        win = IplotQtMainWindow()
+        try:
+            self._add_canvas(win)
+            win.refresh_minimap_availability()
+            self.assertTrue(win.toolBar.minimapAction.isEnabled())
+        finally:
+            win.close()
+
+    def test_minimap_action_disabled_for_multi_plot_canvas(self):
+        win = IplotQtMainWindow()
+        try:
+            multi = Canvas(2, 1)
+            for _ in range(2):
+                p = PlotXY()
+                sig = SignalXY(label='s')
+                sig.set_data([np.linspace(0, 1, 10), np.zeros(10)])
+                p.add_signal(sig)
+                multi.add_plot(p, 0)
+            self._add_canvas(win, multi)
+            win.refresh_minimap_availability()
+            self.assertFalse(win.toolBar.minimapAction.isEnabled())
+        finally:
+            win.close()
+
+    def test_toggle_minimap_updates_canvas_flag(self):
+        win = IplotQtMainWindow()
+        try:
+            qt_canvas = self._add_canvas(win)
+            win.refresh_minimap_availability()
+            win.toolBar.minimapAction.setChecked(True)
+            self.app.processEvents()
+            self.assertTrue(qt_canvas.get_canvas().show_minimap)
+            win.toolBar.minimapAction.setChecked(False)
+            self.app.processEvents()
+            self.assertFalse(qt_canvas.get_canvas().show_minimap)
+        finally:
+            win.close()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Toolbar action to show/hide a mini-map below the main plot, available when a single PlotXY is visible (single-plot canvas or focus mode). The mini-map renders the target signal over the original time window captured at draw time and highlights the current zoom/pan region with a viewport rectangle that updates in real time. Supports matplotlib and pyqtgraph backends; persisted in workspace via Canvas.show_minimap.