### PR TITLE
Fix 119: avoid crash plotting no-data signals via pulse id

### DIFF
--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -524,10 +524,9 @@ class BackendParserBase(ABC):
 
         # Set axis limits
         if ax_idx != 1 or not self.canvas.streaming:  # In case of Streaming, just set X limits at the start
-            # Recalculate when limits are missing OR degenerate (begin == end), which
-            # can happen with single-point workspaces where the stored range doesn't
-            # span the data of all signals sharing the axis.
-            if (axis.begin is None and axis.end is None) or (axis.begin == axis.end):
+            # Recalculate when the stored range is unusable: either end undefined, or
+            # degenerate (begin == end) as with single-point workspaces.
+            if axis.begin is None or axis.end is None or axis.begin == axis.end:
                 self.update_original_axis_limits(axis, impl_plot, ax_idx)
                 padding_begin, padding_end = True, True
 

--- a/iplotlib/standalone/tests/test_backend_pipeline.py
+++ b/iplotlib/standalone/tests/test_backend_pipeline.py
@@ -117,6 +117,25 @@ class BackendPipelineTest(unittest.TestCase):
                 pm = qt_canvas.grab()
                 self.assertFalse(pm.isNull())
 
+    def test_x_range_open_at_one_end_with_empty_signal(self):
+        """An X range with one end undefined and a no-data signal must draw, not raise."""
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas = Canvas(1, 1, title="open_range")
+                plot = PlotXY()
+                sig = SignalXY(label="empty")
+                sig.set_data([np.array([]), np.array([])])
+                plot.add_signal(sig)
+                x_axis = plot.axes[0]
+                x_axis.set_limits(0, None, 'original')
+                x_axis.set_limits(0, None, 'current')
+                canvas.add_plot(plot, 0)
+
+                qt_canvas = self._build(backend, canvas)
+
+                pm = qt_canvas.grab()
+                self.assertFalse(pm.isNull())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In Pulse Id mode a plot whose signals all return no data leaves the X axis end undefined (begin is set to 0, end stays None). The limit recompute only ran when both ends were None, so a half-open range reached create_offset and raised "TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'". Time-range mode was unaffected because both ends are always supplied.

- impl_base: recompute the axis range when either end is None (not only when both are), reusing the existing no-data fallback in update_original_axis_limits.
- tests: add regression covering an X range open at one end with an empty signal, on both backends.