### PR TITLE
Update matplotlibCanvas.py

### DIFF
--- a/iplotlib/impl/matplotlib/matplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/matplotlibCanvas.py
@@ -1262,8 +1262,9 @@ class MatplotlibParser(BackendParserBase):
                 continue
 
             # Check for slider axes
-            filtered_axes_group = [ax for ax in axes_group if ax.get_label() != "slider"]
-
+            filtered_axes_group = [ax for ax in axes_group if ax.get_label() != "slider" and self._impl_plot_cache_table.get_cache_item(ax) is not None]
+            if not filtered_axes_group:
+                continue
             self._cursors.append(
                 IplotMultiCursor(self.figure.canvas, filtered_axes_group,
                                  x_label=self._pm.get_value(self.canvas, 'enable_x_label_crosshair'),


### PR DESCRIPTION
thanks to Claude, issue is only for matplotlib
Fix #1 alone resolves the traceback; fix #2 protects against any future case where an unregistered axes (e.g. the divider.append_axes cax used by create_image, twin axes, etc.) slips into the cursor's axes list. Note create_image's colorbar cax has the same problem, so PlotImage + crosshair would hit the identical crash — the cache-item filter covers both. One nuance to verify on your side: with crosshair_per_plot = True, the grouping loop already filters by cache item (if hasattr(ci, 'plot') and ci.plot()), which is why the bug only shows up in the shared-crosshair path.