### PR TITLE
Add optional progress callback to CSV signal export

### DIFF
--- a/iplotlib/core/canvas.py
+++ b/iplotlib/core/canvas.py
@@ -376,14 +376,32 @@ class Canvas(ABC):
                         if clear is not None:
                             clear()
 
-    def get_signals_as_csv(self):
+    def get_signals_as_csv(self, progress_callback=None):
+        """
+        Serialize the signals of the exported plots to CSV.
+
+        If given, `progress_callback` is invoked as each signal starts being
+        processed with (index, total, signal name), index being 1-based.
+        """
         x = pd.DataFrame()
         focus_plot = self.focus_plot
-        for c, column in enumerate(self.plots):
-            for r, row in enumerate(column):
-                if not row or (focus_plot and row != focus_plot):
-                    continue
-                df = row.get_signals_as_df(r, c)
-                x = pd.concat([x, df], axis=1)
+        exported_plots = [(r, c, row)
+                          for c, column in enumerate(self.plots)
+                          for r, row in enumerate(column)
+                          if row and not (focus_plot and row != focus_plot)]
+
+        per_signal = None
+        if progress_callback is not None:
+            total = sum(len(signals) for _, _, plot in exported_plots for signals in plot.signals.values())
+            counter = 0
+
+            def per_signal(name):
+                nonlocal counter
+                counter += 1
+                progress_callback(counter, total, name)
+
+        for r, c, row in exported_plots:
+            df = row.get_signals_as_df(r, c, progress_callback=per_signal)
+            x = pd.concat([x, df], axis=1)
 
         return x.to_csv(index=False)

--- a/iplotlib/core/plot.py
+++ b/iplotlib/core/plot.py
@@ -137,7 +137,7 @@ class Plot(ABC):
         # signals are merged at canvas level to handle move between plots
 
     @abstractmethod
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         """"""
 
     def set_x_axes_limits(self, limits, which='current'):
@@ -185,10 +185,12 @@ class PlotContour(Plot):
         self.color_map = old_plot['color_map']
         self.contour_levels = old_plot['contour_levels']
 
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         x = pd.DataFrame()
         for p, plot in enumerate(self.signals.values()):
             for s, pl_signal in enumerate(plot):
+                if progress_callback is not None:
+                    progress_callback(pl_signal.alias or pl_signal.name)
                 col_name = f"plot{row + 1}.{col + 1}"
                 if len(self.signals) > 1:
                     col_name += f".{p + 1}"
@@ -278,10 +280,12 @@ class PlotXY(Plot):
         self.marker_size = old_plot['marker_size']
         self.step = old_plot['step']
 
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         x = pd.DataFrame()
         for p, plot in enumerate(self.signals.values()):
             for s, pl_signal in enumerate(plot):
+                if progress_callback is not None:
+                    progress_callback(pl_signal.alias or pl_signal.name)
                 col_name = f"plot{row + 1}.{col + 1}"
                 if len(self.signals) > 1:
                     col_name += f".{p + 1}"
@@ -338,7 +342,7 @@ class PlotSurface(Plot):
     def merge(self, old_plot: dict):
         super().merge(old_plot)
 
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         """"""
 
 
@@ -356,7 +360,7 @@ class PlotImage(Plot):
     def merge(self, old_plot: dict):
         super().merge(old_plot)
 
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         """"""
 
 
@@ -398,10 +402,12 @@ class PlotXYWithSlider(PlotXY):
     def clean_slider(self):
         self.slider = None
 
-    def get_signals_as_df(self, row, col):
+    def get_signals_as_df(self, row, col, progress_callback=None):
         x = pd.DataFrame()
         for p, plot in enumerate(self.signals.values()):
             for s, pl_signal in enumerate(plot):
+                if progress_callback is not None:
+                    progress_callback(pl_signal.alias or pl_signal.name)
                 col_name = f"plot{row + 1}.{col + 1}"
                 if len(self.signals) > 1:
                     col_name += f".{p + 1}"


### PR DESCRIPTION
get_signals_as_csv and get_signals_as_df accept a progress_callback invoked per signal with (index, total, name). Defaults to None, keeping the previous behaviour untouched.