### PR TITLE
feat: add Home button to reset all plots to the draw-time range

### DIFF
--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -154,6 +154,7 @@ class BackendParserBase(ABC):
         self._impl_plot_ranges_hash = defaultdict(
             lambda: defaultdict(dict))  # type: Dict[Any, int] # key is id(impl_plot)
         self._update = False
+        self._restoring_view = False
         self._streaming_impl_plot_lut = defaultdict(lambda: [None, None])
 
     def run_in_one_thread(func):
@@ -638,6 +639,22 @@ class BackendParserBase(ABC):
         """
         """
 
+    def _draw_time_signal_data(self, signal: Signal, impl_plot: Any):
+        """
+        Data for redrawing `signal` while the view is being reset: the draw-time
+        snapshot (``restore_minimap_snapshot``), served without any data access.
+        Returns None when the snapshot cannot honour the plot (no snapshot yet,
+        or slider/contour/image data, which it does not capture).
+        """
+        if not isinstance(signal, SignalXY):
+            return None
+        ci = self._impl_plot_cache_table.get_cache_item(impl_plot)
+        plot = ci.plot() if ci else None
+        if plot is None or isinstance(plot, (PlotXYWithSlider, PlotContour, PlotImage)):
+            return None
+        restore = getattr(signal, 'restore_minimap_snapshot', None)
+        return restore() if restore is not None else None
+
     @run_in_one_thread
     def process_ipl_signal(self, signal: Signal):
         """
@@ -657,8 +674,14 @@ class BackendParserBase(ABC):
         if impl_plot is None:
             return
 
-        # All good, make a data access request
-        signal_data = signal.get_data()
+        if self._restoring_view:
+            # View reset: redraw from the draw-time snapshot, never re-request data.
+            signal_data = self._draw_time_signal_data(signal, impl_plot)
+            if signal_data is None:
+                return
+        else:
+            # All good, make a data access request
+            signal_data = signal.get_data()
 
         # Apply shift offsets if present (persisted in signal metadata)
         # This ensures offset survives any rebuild/refresh cycle
@@ -1440,8 +1463,9 @@ class BackendParserBase(ABC):
         limits), leaving every other plot untouched. The X range is the exact window
         requested at draw time; the Y range gets the same margin Draw applies.
 
-        Reuses the view-limit plumbing of undo/redo, so the redraw is served from
-        cached/in-memory data rather than triggering a fresh request.
+        Reuses the view-limit plumbing of undo/redo, and the redraws it triggers are
+        served from the draw-time snapshots (:meth:`_draw_time_signal_data`), so no
+        data-access request is issued.
         """
         target = self.get_plot_limits(impl_plot)
         if not isinstance(target, IplPlotViewLimits):
@@ -1462,7 +1486,11 @@ class BackendParserBase(ABC):
         for signal_range in target.signals_ranges:
             signal_range.set_limits(x_begin, x_end)
 
-        self.set_plot_limits(target)
+        self._restoring_view = True
+        try:
+            self.set_plot_limits(target)
+        finally:
+            self._restoring_view = False
 
     def reset_all_plots_to_original(self):
         """

--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -1418,6 +1418,71 @@ class BackendParserBase(ABC):
         if isinstance(plot, PlotXYWithSlider) and self._pm.get_value(self.canvas, 'shared_x_axis'):
             self.set_impl_plot_slider_limits(plot, *limits.sliders_ranges[0].get_limits())
 
+    def _draw_time_y_limits(self, plot, begin, end):
+        """
+        Return the Y range as Draw would show it: the original extent plus the 10%
+        margin, unless a canvas-level Y min/max override is set (then it wins, with
+        no margin). Contour and image plots get no margin. Mirrors the Y handling in
+        :meth:`process_ipl_axis`.
+        """
+        if begin is None or end is None or isinstance(plot, (PlotContour, PlotImage)):
+            return begin, end
+        canvas_begin = self.canvas.canvas_begin
+        canvas_end = self.canvas.canvas_end
+        height = end - begin
+        lo = canvas_begin if canvas_begin is not None else begin - 0.1 * height
+        hi = canvas_end if canvas_end is not None else end + 0.1 * height
+        return lo, hi
+
+    def set_plot_limits_to_original(self, impl_plot: Any):
+        """
+        Restore a single plot to the ranges captured at draw time (the ``original``
+        limits), leaving every other plot untouched. The X range is the exact window
+        requested at draw time; the Y range gets the same margin Draw applies.
+
+        Reuses the view-limit plumbing of undo/redo, so the redraw is served from
+        cached/in-memory data rather than triggering a fresh request.
+        """
+        target = self.get_plot_limits(impl_plot)
+        if not isinstance(target, IplPlotViewLimits):
+            return
+        plot = target.plot_ref()
+        if plot is None:
+            return
+
+        x_begin, x_end = plot.axes[0].get_limits('original')
+        stacked_plots = self._plot_impl_plot_lut.get(id(plot))
+        y_begin, y_end = plot.axes[1][stacked_plots.index(impl_plot)].get_limits('original')
+        y_begin, y_end = self._draw_time_y_limits(plot, y_begin, y_end)
+
+        target.axes_ranges[0].set_limits(x_begin, x_end)
+        target.axes_ranges[1].set_limits(y_begin, y_end)
+        # Signals inherit the plot's X range; realign them to the draw-time window
+        # so their cached samples are reused on redraw.
+        for signal_range in target.signals_ranges:
+            signal_range.set_limits(x_begin, x_end)
+
+        self.set_plot_limits(target)
+
+    def reset_all_plots_to_original(self):
+        """
+        Restore every visible plot to its draw-time ranges. Plots hidden by focus
+        mode are skipped, mirroring the iteration in :meth:`get_all_plot_limits`.
+        """
+        if not isinstance(self.canvas, Canvas):
+            return
+        for col in self.canvas.plots:
+            for plot in col:
+                if plot is None:
+                    continue
+                if self._focus_plot is not None and self._focus_plot != plot:
+                    continue
+                impl_list = self._plot_impl_plot_lut.get(id(plot))
+                if not impl_list:
+                    continue
+                for impl_plot in impl_list:
+                    self.set_plot_limits_to_original(impl_plot)
+
     @staticmethod
     def create_offset(vals: Union[List, BufferObject]) -> Union[int, np.int64, np.uint64, None]:
         """

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -446,6 +446,9 @@ class QtMatplotlibCanvas(IplotQtCanvas):
     def render(self):
         self._mpl_renderer.draw()
 
+    def _flush_view(self):
+        self.render()
+
     # custom event handlers
     def _mpl_draw_finish(self, event: DrawEvent):
         self._draw_call_counter += 1
@@ -808,6 +811,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         autoscale_menu = QMenu(self)
         autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(event.inaxes))
         autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
+        autoscale_menu.addAction("Reset zoom/pan", lambda: self.reset_plot_view(event.inaxes))
         if self._parser.canvas.focus_plot is None:
             autoscale_menu.addAction("Focus on plot", lambda: self._full_screen_mode_on(event.inaxes))
         else:

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -702,6 +702,7 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
             autoscale_menu = QMenu(self)
             autoscale_menu.addAction("Autoscale", lambda: self.autoscale_y(impl_plot))
             autoscale_menu.addAction("Autoscale All", self.autoscale_all_y)
+            autoscale_menu.addAction("Reset zoom/pan", lambda: self.reset_plot_view(impl_plot))
             if self._parser.canvas.focus_plot is None:
                 autoscale_menu.addAction("Focus on plot",
                                          lambda: self._full_screen_mode_on(impl_plot))

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -556,9 +556,12 @@ class IplotSignalAdapter(ProcessingSignal):
         self.y_data = y_data.copy()
         if envelope:
             self.z_data = self._minimap_y_max_data.copy()
+            # Realign the raw envelope store: statistics index min/max/avg by the displayed data.
+            self.data_store[0] = self.x_data
+            self.data_store[1] = self.y_data
+            self.data_store[2] = self.z_data
             self.data_store[3] = self._minimap_y_avg_data.copy()
-        # Restore the draw-time downsampled state too: it drives the legend
-        # marker and the decision to fetch finer data on the next zoom.
+        # The downsampled state drives the legend marker and the next-zoom refetch.
         self.isDownsampled = self._minimap_is_downsampled
         self._access_md5sum = self.calculate_data_hash()
         self.set_da_success()

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -150,6 +150,7 @@ class IplotSignalAdapter(ProcessingSignal):
         self._minimap_y_data = None
         self._minimap_y_max_data = None
         self._minimap_y_avg_data = None
+        self._minimap_is_downsampled = False
 
         # 2. Post-initialize ArraySignal's properties and our name.
         self._init_label()
@@ -517,6 +518,7 @@ class IplotSignalAdapter(ProcessingSignal):
         if self._minimap_x_data is None and len(self.x_data) > 0:
             self._minimap_x_data = self.x_data.copy()
             self._minimap_y_data = self.y_data.copy()
+            self._minimap_is_downsampled = self.isDownsampled
             if (getattr(self, 'envelope', False) and len(self.data_store) >= 4
                     and len(self.z_data) == len(self.x_data)
                     and len(self.data_store[3]) == len(self.x_data)):
@@ -531,12 +533,13 @@ class IplotSignalAdapter(ProcessingSignal):
         self._minimap_y_data = None
         self._minimap_y_max_data = None
         self._minimap_y_avg_data = None
+        self._minimap_is_downsampled = False
 
     def restore_minimap_snapshot(self):
         """
-        Restore the buffers to the full-range data captured at draw time (the same
-        snapshot the minimap renders) and return it shaped like :meth:`get_data`,
-        or None when no snapshot is available.
+        Restore the buffers and the downsampled state to the full-range data
+        captured at draw time (the same snapshot the minimap renders) and return
+        it shaped like :meth:`get_data`, or None when no snapshot is available.
 
         The data hash is refreshed so the restored buffers count as up to date for
         the current time range: redisplaying them triggers no data access.
@@ -554,6 +557,9 @@ class IplotSignalAdapter(ProcessingSignal):
         if envelope:
             self.z_data = self._minimap_y_max_data.copy()
             self.data_store[3] = self._minimap_y_avg_data.copy()
+        # Restore the draw-time downsampled state too: it drives the legend
+        # marker and the decision to fetch finer data on the next zoom.
+        self.isDownsampled = self._minimap_is_downsampled
         self._access_md5sum = self.calculate_data_hash()
         self.set_da_success()
 

--- a/iplotlib/interface/iplotSignalAdapter.py
+++ b/iplotlib/interface/iplotSignalAdapter.py
@@ -532,6 +532,35 @@ class IplotSignalAdapter(ProcessingSignal):
         self._minimap_y_max_data = None
         self._minimap_y_avg_data = None
 
+    def restore_minimap_snapshot(self):
+        """
+        Restore the buffers to the full-range data captured at draw time (the same
+        snapshot the minimap renders) and return it shaped like :meth:`get_data`,
+        or None when no snapshot is available.
+
+        The data hash is refreshed so the restored buffers count as up to date for
+        the current time range: redisplaying them triggers no data access.
+        """
+        x_data = self._minimap_x_data
+        y_data = self._minimap_y_data
+        if x_data is None or y_data is None or len(x_data) == 0:
+            return None
+        envelope = getattr(self, 'envelope', False)
+        if envelope and (self._minimap_y_max_data is None or self._minimap_y_avg_data is None):
+            return None
+
+        self.x_data = x_data.copy()
+        self.y_data = y_data.copy()
+        if envelope:
+            self.z_data = self._minimap_y_max_data.copy()
+            self.data_store[3] = self._minimap_y_avg_data.copy()
+        self._access_md5sum = self.calculate_data_hash()
+        self.set_da_success()
+
+        if envelope:
+            return [self.x_data, self.y_data, self.z_data, self.data_store[3]]
+        return [self.x_data, self.y_data, self.z_data]
+
     def _process_data(self):
         # 1. Cannot process data when _fetch_data failed or did not occur
         if self.data_access_enabled and self.status_info.result != Result.SUCCESS:

--- a/iplotlib/qt/gui/iplotCanvasToolbar.py
+++ b/iplotlib/qt/gui/iplotCanvasToolbar.py
@@ -74,7 +74,7 @@ class IplotQtCanvasToolbar(QToolBar):
 
         # Restore every plot to the range captured at draw time.
         self.homeAction = QAction(create_icon('home', 'svg'), '&Home', self)
-        self.homeAction.setToolTip('Reset all plots to the draw-time range')
+        self.homeAction.setToolTip('Resets all plots to the original view')
         self.addAction(self.homeAction)
 
         # Saving, etc..

--- a/iplotlib/qt/gui/iplotCanvasToolbar.py
+++ b/iplotlib/qt/gui/iplotCanvasToolbar.py
@@ -72,6 +72,11 @@ class IplotQtCanvasToolbar(QToolBar):
         self.addAction(self.undoAction)
         self.addAction(self.redoAction)
 
+        # Restore every plot to the range captured at draw time.
+        self.homeAction = QAction(create_icon('home', 'svg'), '&Home', self)
+        self.homeAction.setToolTip('Reset all plots to the draw-time range')
+        self.addAction(self.homeAction)
+
         # Saving, etc..
         self.importAction = QAction(create_icon('open_file'), '&Import Workspace', self)
         self.exportAction = QAction(create_icon('save_as'), '&Export Workspace', self)

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -409,9 +409,8 @@ class IplotQtCanvas(QWidget):
         # Check if any limit actually changed
         if any([lim1 != lim2 for lim1, lim2 in zip(cmd.old_lim, cmd.new_lim)]):
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-            # Flush pending work without dispatching user input: this runs inside
-            # the mouse-release handler, and re-entering it mid-release corrupts
-            # the backends' drag state. Queued clicks are delivered afterwards.
+            # Exclude user input: this runs inside the mouse-release handler and
+            # re-entering it corrupts the backends' drag state.
             QApplication.processEvents(QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
             QApplication.restoreOverrideCursor()
 

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from typing import List, Tuple, Optional
 
 import numpy as np
-from PySide6.QtCore import QMetaObject, QSize, Qt, Signal, Slot
+from PySide6.QtCore import QEventLoop, QMetaObject, QSize, Qt, Signal, Slot
 from PySide6.QtWidgets import QApplication, QWidget, QMessageBox
 from iplotlib.core.signal import SignalXY
 from iplotlib.core.canvas import Canvas
@@ -409,7 +409,10 @@ class IplotQtCanvas(QWidget):
         # Check if any limit actually changed
         if any([lim1 != lim2 for lim1, lim2 in zip(cmd.old_lim, cmd.new_lim)]):
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-            QApplication.processEvents()
+            # Flush pending work without dispatching user input: this runs inside
+            # the mouse-release handler, and re-entering it mid-release corrupts
+            # the backends' drag state. Queued clicks are delivered afterwards.
+            QApplication.processEvents(QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
             QApplication.restoreOverrideCursor()
 
             # Update new limits after data refresh.

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -13,7 +13,7 @@ from PySide6.QtCore import QMetaObject, QSize, Qt, Signal, Slot
 from PySide6.QtWidgets import QApplication, QWidget, QMessageBox
 from iplotlib.core.signal import SignalXY
 from iplotlib.core.canvas import Canvas
-from iplotlib.core.plot import PlotXYWithSlider, PlotContourWithSlider
+from iplotlib.core.plot import PlotXY, PlotXYWithSlider, PlotContourWithSlider
 from iplotlib.core.command import IplotCommand
 from iplotlib.core.drop_info import DropInfo
 from iplotlib.core.commands.axes_range import IplotAxesRangeCmd
@@ -390,12 +390,13 @@ class IplotQtCanvas(QWidget):
         finally:
             self._parser._hm.undo()
 
-    def stage_view_lim_cmd(self, impl_plot):
-        """stage a view command"""
+    def stage_view_lim_cmd(self, impl_plot, name: str = None):
+        """stage a view command. `name` labels the command; defaults to the active mouse mode."""
 
-        name = self._mmode[3:]
+        if name is None:
+            name = self._mmode[3:].capitalize()
         old_limits = [self._parser.get_plot_limits(impl_plot)]
-        cmd = IplotAxesRangeCmd(name.capitalize(), old_limits, parser=self._parser)
+        cmd = IplotAxesRangeCmd(name, old_limits, parser=self._parser)
         self._staging_cmds.append(cmd)
         logger.debug(f"Staged {cmd}")
 
@@ -433,6 +434,49 @@ class IplotQtCanvas(QWidget):
             self.cmdDone.emit(cmd)
         except IndexError:
             return
+
+    def _flush_view(self):
+        """
+        Redraw after a view-limit change. Backends that repaint eagerly on range
+        changes (pyqtgraph) need nothing here; matplotlib overrides this.
+        """
+
+    def reset_plot_view(self, impl_plot):
+        """
+        Restore a single plot to its draw-time view (the "Reset zoom/pan" action),
+        leaving every other plot untouched. Recorded as one undoable command,
+        mirroring the autoscale flow.
+        """
+        ci = self._parser._impl_plot_cache_table.get_cache_item(impl_plot)
+        if not hasattr(ci, 'plot') or not isinstance(ci.plot(), PlotXY):
+            return
+        self.stage_view_lim_cmd(impl_plot, name='Reset zoom/pan')
+        self._parser.set_plot_limits_to_original(impl_plot)
+        while len(self._staging_cmds):
+            self.commit_view_lim_cmd(impl_plot)
+        while len(self._commitd_cmds):
+            self.push_view_lim_cmd()
+        self._flush_view()
+        self.stats(self.get_canvas())
+
+    def reset_all_views(self):
+        """
+        Restore every plot to its draw-time view (the toolbar "Home" action).
+        Captured as a single undoable command so one undo reverts the whole reset.
+        """
+        if self._parser is None or self.get_canvas() is None:
+            return
+        old_limits = self._parser.get_all_plot_limits()
+        if not old_limits:
+            return
+        cmd = IplotAxesRangeCmd('Home', old_limits, parser=self._parser)
+        self._parser.reset_all_plots_to_original()
+        cmd.new_lim = self._parser.get_all_plot_limits()
+        if any(old != new for old, new in zip(cmd.old_lim, cmd.new_lim)):
+            self._parser._hm.done(cmd)
+            self.cmdDone.emit(cmd)
+        self._flush_view()
+        self.stats(self.get_canvas())
 
     def clean_canvas(self):
         """

--- a/iplotlib/qt/gui/iplotQtMainWindow.py
+++ b/iplotlib/qt/gui/iplotQtMainWindow.py
@@ -66,6 +66,7 @@ class IplotQtMainWindow(QMainWindow):
     def wire_connections(self):
         self.toolBar.undoAction.triggered.connect(self.undo)
         self.toolBar.redoAction.triggered.connect(self.redo)
+        self.toolBar.homeAction.triggered.connect(self.home)
         self.toolBar.statistics.triggered.connect(self.show_stats)
         self.toolBar.minimapAction.toggled.connect(self.on_minimap_toggled)
         self.toolBar.toolActivated.connect(
@@ -102,6 +103,16 @@ class IplotQtMainWindow(QMainWindow):
         w.redo()
         # Computation of the statistics after redo operation
         w.stats(w.get_canvas())
+        QApplication.restoreOverrideCursor()
+        self.check_history(w)
+
+    def home(self):
+        """Restore every plot to the range captured at draw time."""
+        w = self.canvasStack.currentWidget()
+        if not w:
+            return
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        w.reset_all_views()
         QApplication.restoreOverrideCursor()
         self.check_history(w)
 

--- a/iplotlib/qt/icons/home.svg
+++ b/iplotlib/qt/icons/home.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M12 3.5 3 11h2v9h5v-6h4v6h5v-9h2z"
+        fill="#3b3b3b" stroke="#3b3b3b" stroke-width="1.3"
+        stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -2,7 +2,8 @@
 
 After a zoom, both actions must restore the axis range captured at draw time,
 reusing the same view-limit plumbing as undo/redo. Home is verified to be a
-single undoable command so one undo reverts the whole reset.
+single undoable command so one undo reverts the whole reset, and to redraw
+from the draw-time snapshot without issuing any data-access request.
 """
 
 import copy
@@ -138,6 +139,59 @@ class ResetViewTest(unittest.TestCase):
                 reset_y = self._y_range(qt_canvas)
                 self.assertAlmostEqual(reset_y[0], draw_y[0], places=3)
                 self.assertAlmostEqual(reset_y[1], draw_y[1], places=3)
+
+    def test_reset_redraws_from_snapshot_without_data_access(self):
+        # Home must serve the redraw from the draw-time snapshot: the signal's
+        # data-access path must not run while the view is being restored, and the
+        # curve must recover its full extent even if a zoom left partial buffers.
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                signal = next(iter(canvas.plots[0][0].signals.values()))[0]
+                full_len = len(signal.x_data)
+
+                calls = {'get_data': 0}
+                original_get_data = signal.get_data
+
+                def spied_get_data():
+                    calls['get_data'] += 1
+                    return original_get_data()
+
+                signal.get_data = spied_get_data
+                self._zoom_in(qt_canvas)
+
+                # Simulate the partial buffers left by a downsampled sub-range refetch.
+                signal.x_data = signal.x_data[:20]
+                signal.y_data = signal.y_data[:20]
+                calls['get_data'] = 0
+
+                qt_canvas.reset_all_views()
+                self.app.processEvents()
+
+                self.assertEqual(calls['get_data'], 0)
+                self.assertEqual(len(signal.x_data), full_len)
+                line = qt_canvas._parser._signal_impl_shape_lut[id(signal)][0]
+                line_x = line.get_xdata() if backend == 'matplotlib' else line.getData()[0]
+                self.assertEqual(len(line_x), full_len)
+
+    def test_restore_minimap_snapshot_roundtrip(self):
+        # The snapshot restore is the inverse of the capture done on first load.
+        x = np.linspace(0, 10, 200)
+        signal = SignalXY(label="s")
+        signal.set_data([x, np.sin(x)])
+        signal.x_data = signal.x_data[:20]
+        signal.y_data = signal.y_data[:20]
+
+        data = signal.restore_minimap_snapshot()
+
+        self.assertIsNotNone(data)
+        self.assertEqual(len(data[0]), 200)
+        self.assertEqual(len(signal.x_data), 200)
+        np.testing.assert_allclose(np.asarray(signal.y_data), np.sin(x))
+
+    def test_restore_minimap_snapshot_without_data(self):
+        signal = SignalXY(label="empty")
+        self.assertIsNone(signal.restore_minimap_snapshot())
 
     def test_home_action_always_enabled(self):
         # Home is always clickable; it is a no-op when there is nothing to reset.

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -193,6 +193,22 @@ class ResetViewTest(unittest.TestCase):
         signal = SignalXY(label="empty")
         self.assertIsNone(signal.restore_minimap_snapshot())
 
+    def test_restore_minimap_snapshot_restores_downsampled_state(self):
+        # A deep zoom can refetch raw data and clear the downsampled flag. The
+        # restore must bring back the draw-time state, so the next zoom fetches
+        # finer data again instead of serving the coarse full-range buffers.
+        x = np.linspace(0, 10, 200)
+        signal = SignalXY(label="s", isDownsampled=True)
+        signal.set_data([x, np.sin(x)])
+        signal.isDownsampled = False
+        signal.x_data = signal.x_data[:20]
+        signal.y_data = signal.y_data[:20]
+
+        signal.restore_minimap_snapshot()
+
+        self.assertTrue(signal.isDownsampled)
+        self.assertEqual(len(signal.x_data), 200)
+
     def test_home_action_always_enabled(self):
         # Home is always clickable; it is a no-op when there is nothing to reset.
         win = IplotQtMainWindow()

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -10,6 +10,7 @@ import copy
 import unittest
 
 import numpy as np
+from iplotProcessing.core import BufferObject
 
 from iplotlib.core.canvas import Canvas
 from iplotlib.core.commands.axes_range import IplotAxesRangeCmd
@@ -192,6 +193,30 @@ class ResetViewTest(unittest.TestCase):
     def test_restore_minimap_snapshot_without_data(self):
         signal = SignalXY(label="empty")
         self.assertIsNone(signal.restore_minimap_snapshot())
+
+    def test_restore_minimap_snapshot_realigns_envelope_store(self):
+        # A zoom refetch of another size must not leave the raw envelope store
+        # misaligned with the displayed data (statistics index it by mask).
+        x = np.linspace(0, 10, 200)
+        signal = SignalXY(label="e", envelope=True)
+        # The avg slot only exists after an envelope fetch; emulate its layout.
+        while len(signal.data_store) < 4:
+            signal.data_store.append(BufferObject())
+        signal.data_store[3] = BufferObject(np.sin(x))
+        signal.set_data([x, np.sin(x) - 1, np.sin(x) + 1])
+
+        signal.x_data = signal.x_data[:50]
+        signal.y_data = signal.y_data[:50]
+        signal.z_data = signal.z_data[:50]
+        for i in range(4):
+            signal.data_store[i] = signal.data_store[i][:53]
+
+        data = signal.restore_minimap_snapshot()
+
+        self.assertEqual(len(data), 4)
+        self.assertEqual(len(signal.x_data), 200)
+        for i in range(4):
+            self.assertEqual(len(signal.data_store[i]), 200)
 
     def test_restore_minimap_snapshot_restores_downsampled_state(self):
         # A deep zoom can refetch raw data and clear the downsampled flag. The

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -1,0 +1,159 @@
+"""Reset-to-draw-range on real backends: toolbar Home and per-plot Reset zoom/pan.
+
+After a zoom, both actions must restore the axis range captured at draw time,
+reusing the same view-limit plumbing as undo/redo. Home is verified to be a
+single undoable command so one undo reverts the whole reset.
+"""
+
+import copy
+import unittest
+
+import numpy as np
+
+from iplotlib.core.canvas import Canvas
+from iplotlib.core.commands.axes_range import IplotAxesRangeCmd
+from iplotlib.core.plot import PlotXY
+from iplotlib.core.signal import SignalXY
+from iplotlib.qt.gui.iplotQtCanvasFactory import IplotQtCanvasFactory
+from iplotlib.qt.gui.iplotQtMainWindow import IplotQtMainWindow
+from iplotlib.qt.testing import ensure_qapp
+
+
+def _make_canvas() -> Canvas:
+    core = Canvas(1, 1, title="reset_view")
+    x = np.linspace(0, 10, 200)
+    plot = PlotXY()
+    signal = SignalXY(label="s")
+    signal.set_data([x, np.sin(x)])
+    plot.add_signal(signal)
+    core.add_plot(plot, 0)
+    return core
+
+
+class ResetViewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.app = ensure_qapp()
+
+    def _build(self, backend: str):
+        canvas = _make_canvas()
+        qt_canvas = IplotQtCanvasFactory.new(backend, canvas=canvas)
+        qt_canvas.set_canvas(canvas)
+        qt_canvas.resize(800, 600)
+        self.app.processEvents()
+        return canvas, qt_canvas
+
+    def _x_range(self, qt_canvas):
+        axis_range = qt_canvas._parser.get_all_plot_limits()[0].axes_ranges[0]
+        return axis_range.begin, axis_range.end
+
+    def _y_range(self, qt_canvas):
+        axis_range = qt_canvas._parser.get_all_plot_limits()[0].axes_ranges[1]
+        return axis_range.begin, axis_range.end
+
+    def _zoom_in(self, qt_canvas, factor: float = 0.25):
+        """Apply a zoom that narrows both X and Y, mimicking a user rubber-band."""
+        parser = qt_canvas._parser
+        current = parser.get_all_plot_limits()
+        narrowed = copy.deepcopy(current)
+        # deepcopy drops weakrefs; restore them from the originals.
+        for src, dst in zip(current, narrowed):
+            dst.plot_ref = src.plot_ref
+            for s_src, s_dst in zip(src.signals_ranges, dst.signals_ranges):
+                s_dst.signal_ref = s_src.signal_ref
+        for axis_idx in (0, 1):
+            rng = current[0].axes_ranges[axis_idx]
+            span = rng.end - rng.begin
+            narrowed[0].axes_ranges[axis_idx].set_limits(rng.begin + span * factor,
+                                                         rng.end - span * factor)
+        cmd = IplotAxesRangeCmd('Zoom', old_limits=current, new_limits=narrowed, parser=parser)
+        parser._hm.done(cmd)
+        cmd()
+        self.app.processEvents()
+
+    def test_reset_all_views_restores_draw_range(self):
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                _, qt_canvas = self._build(backend)
+                original = self._x_range(qt_canvas)
+                self._zoom_in(qt_canvas)
+                self.assertNotAlmostEqual(self._x_range(qt_canvas)[0], original[0], places=3)
+
+                qt_canvas.reset_all_views()
+                self.app.processEvents()
+
+                restored = self._x_range(qt_canvas)
+                self.assertAlmostEqual(restored[0], original[0], places=3)
+                self.assertAlmostEqual(restored[1], original[1], places=3)
+
+    def test_reset_plot_view_restores_draw_range(self):
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                original = self._x_range(qt_canvas)
+                self._zoom_in(qt_canvas)
+
+                plot = canvas.plots[0][0]
+                impl_plot = qt_canvas._parser._plot_impl_plot_lut[id(plot)][0]
+                qt_canvas.reset_plot_view(impl_plot)
+                self.app.processEvents()
+
+                restored = self._x_range(qt_canvas)
+                self.assertAlmostEqual(restored[0], original[0], places=3)
+                self.assertAlmostEqual(restored[1], original[1], places=3)
+
+    def test_home_is_single_undoable_command(self):
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                _, qt_canvas = self._build(backend)
+                self._zoom_in(qt_canvas)
+                zoomed = self._x_range(qt_canvas)
+
+                qt_canvas.reset_all_views()
+                self.app.processEvents()
+
+                self.assertTrue(qt_canvas.can_undo())
+                self.assertEqual(qt_canvas.get_next_undo_cmd_name(), 'Home')
+
+                qt_canvas._parser._hm.undo()
+                self.app.processEvents()
+
+                reverted = self._x_range(qt_canvas)
+                self.assertAlmostEqual(reverted[0], zoomed[0], places=3)
+                self.assertAlmostEqual(reverted[1], zoomed[1], places=3)
+
+    def test_reset_restores_draw_time_y_margin(self):
+        # The reset must reproduce the Draw view including the Y margin, not the
+        # tighter raw-data extent.
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                _, qt_canvas = self._build(backend)
+                draw_y = self._y_range(qt_canvas)
+                self._zoom_in(qt_canvas)
+                self.assertNotAlmostEqual(self._y_range(qt_canvas)[0], draw_y[0], places=3)
+
+                qt_canvas.reset_all_views()
+                self.app.processEvents()
+
+                reset_y = self._y_range(qt_canvas)
+                self.assertAlmostEqual(reset_y[0], draw_y[0], places=3)
+                self.assertAlmostEqual(reset_y[1], draw_y[1], places=3)
+
+    def test_home_action_always_enabled(self):
+        # Home is always clickable; it is a no-op when there is nothing to reset.
+        win = IplotQtMainWindow()
+        try:
+            qt_canvas = IplotQtCanvasFactory.new('matplotlib', canvas=_make_canvas())
+            qt_canvas.set_canvas(qt_canvas.get_canvas())
+            win.canvasStack.addWidget(qt_canvas)
+            self.app.processEvents()
+            self.assertTrue(win.toolBar.homeAction.isEnabled())
+
+            win.check_history(qt_canvas)
+            self.assertTrue(win.toolBar.homeAction.isEnabled())
+        finally:
+            win.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Home restores every plot to the range of the last Draw; the right-click menu gets a per-plot "Reset zoom/pan" for when shared time is off. Both reuse the undo/redo view-limit plumbing, so the redraw comes from cache. X returns to the exact Draw window, Y keeps Draw's 10% margin. Single undoable command.

Ref iplot-viz/mint#131