### PR TITLE
feat(canvas): let the host application extend the plot context menu

### DIFF
--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -846,6 +846,12 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         if nearest_signal:
             autoscale_menu.addAction("Signal Preferences",
                                      lambda s=nearest_signal: self.openPlotPreferences.emit(s))
+        extender = getattr(self._parser, 'context_menu_extender', None)
+        if callable(extender):
+            try:
+                extender(autoscale_menu, ci.plot() if ci else None)
+            except Exception:
+                logger.exception("context_menu_extender failed")
         autoscale_menu.popup(event.guiEvent.globalPos())
 
     def keyPressEvent(self, event: QKeyEvent):

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -758,6 +758,12 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
             if nearest_signal:
                 autoscale_menu.addAction("Signal Preferences",
                                          lambda s=nearest_signal: self.openPlotPreferences.emit(s))
+            extender = getattr(self._parser, 'context_menu_extender', None)
+            if callable(extender):
+                try:
+                    extender(autoscale_menu, ci.plot() if ci else None)
+                except Exception:
+                    logger.exception("context_menu_extender failed")
             screen_pos = event.screenPos()
             if hasattr(screen_pos, 'toPoint'):
                 screen_pos = screen_pos.toPoint()


### PR DESCRIPTION
Both backends invoke parser.context_menu_extender, when set, while building the right-click menu, and pass the plot under the cursor so the host can act per-plot. Enables MINT's "Set as time window" (#107).