### PR TITLE
List every plot a ruler spans in the Rulers window (#152)

### DIFF
--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -22,7 +22,7 @@ import numpy as np
 from queue import Empty, Queue
 import re
 import threading
-from typing import Any, Callable, Collection, Dict, List, Optional, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Union
 import weakref
 
 from iplotProcessing.core import BufferObject
@@ -940,21 +940,19 @@ class BackendParserBase(ABC):
         ruler support override this; the base has no per-signal resolution."""
         return {}
 
-    def ruler_signal_values_shared(self, impl_plot: Any, x_view: float) -> Dict[str, float]:
-        """Signal values at the ruler X for *impl_plot* extended, when the canvas
-        shares the time axis, with the signals of every shared plot evaluated at
-        the same absolute X — the values the ruler echoes display. The owner
-        plot wins on a label clash."""
-        values: Dict[str, float] = {}
+    def ruler_reach(self, impl_plot: Any, x_view: float) -> List[Tuple[Any, float, Dict[str, float]]]:
+        """Every plot a ruler placed on *impl_plot* draws on, owner first, as
+        (plot, x in that plot's view coordinates, its signals' values there).
+        Merging the values would drop one of two signals sharing a label."""
+        reach = [(impl_plot, x_view, self._ruler_signal_values(impl_plot, x_view))]
         if self._pm.get_value(self.canvas, 'shared_x_axis'):
             x_abs = self.transform_value(impl_plot, 0, x_view)
             for sibling in self._get_all_shared_axes(impl_plot):
                 if sibling is impl_plot:
                     continue
                 x_sibling = self.transform_value(sibling, 0, x_abs, inverse=True)
-                values.update(self._ruler_signal_values(sibling, x_sibling))
-        values.update(self._ruler_signal_values(impl_plot, x_view))
-        return values
+                reach.append((sibling, x_sibling, self._ruler_signal_values(sibling, x_sibling)))
+        return reach
 
     @abstractmethod
     def get_canvas_plots(self):

--- a/iplotlib/impl/matplotlib/iplotMplRuler.py
+++ b/iplotlib/impl/matplotlib/iplotMplRuler.py
@@ -25,7 +25,8 @@ class iplotMplRuler:
                  lw: int = 1,
                  font_size: int = 8,
                  animated: bool = False,
-                 value_lines: List = None):
+                 value_lines: List = None,
+                 is_echo: bool = False):
         self.ax = ax
         self.name = name
         self.xy = xy
@@ -33,7 +34,7 @@ class iplotMplRuler:
         # refresh so zoom/pan keep the ruler anchored to its data position.
         self.abs_x = xy[0]
         self.abs_y = xy[1]
-        self.is_echo = False
+        self.is_echo = is_echo
         self.color = color
         self.font_color = font_color
         self.font_size = font_size
@@ -129,7 +130,9 @@ class iplotMplRuler:
         xmin, xmax = sorted(self.ax.get_xlim())
         ymin, ymax = sorted(self.ax.get_ylim())
         in_x = xmin <= x <= xmax
-        in_y = ymin <= y <= ymax
+        # A mirrored copy carries the owner's Y against an unrelated scale, so it
+        # keeps the time line only.
+        in_y = (ymin <= y <= ymax) and not self.is_echo
         self.v_line.set_visible(in_x)
         self.x_label.set_visible(in_x)
         self.h_line.set_visible(in_x and in_y)

--- a/iplotlib/impl/matplotlib/matplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/matplotlibCanvas.py
@@ -1503,10 +1503,10 @@ class MatplotlibParser(BackendParserBase):
         font_size = int(self._pm.get_value(self.canvas, 'font_size') or 8)
         ruler = iplotMplRuler(ax=impl_plot, name=name, xy=(x, y), color=color,
                               font_size=font_size, animated=animated,
-                              value_lines=self._ruler_value_lines(impl_plot))
+                              value_lines=self._ruler_value_lines(impl_plot),
+                              is_echo=is_echo)
         ruler.abs_x = self.transform_value(impl_plot, 0, x)
         ruler.abs_y = self.transform_value(impl_plot, 1, y)
-        ruler.is_echo = is_echo
         self._rulers.append(ruler)
         return ruler
 

--- a/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/qt/qtMatplotlibCanvas.py
@@ -405,7 +405,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         # The freed name may change what the next ruler will be called.
         self._clear_preview_ruler()
         self._preview_ruler_identity = None
-        self.render()
+        self.render_deferred()
 
     def toggle_ruler_visibility(self, name, plot_id, visible):
         plot = self._get_plot_by_id(plot_id)
@@ -418,7 +418,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         for r in self._parser.get_rulers():
             if r.name == name:
                 r.set_visible(visible)
-        self.render()
+        self.render_deferred()
 
     def change_ruler_color(self, name, plot_id, color):
         plot = self._get_plot_by_id(plot_id)
@@ -430,7 +430,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         for r in self._parser.get_rulers():
             if r.name == name:
                 r.set_color(color)
-        self.render()
+        self.render_deferred()
 
     def change_ruler_font_color(self, name, plot_id, color):
         plot = self._get_plot_by_id(plot_id)
@@ -442,7 +442,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         for r in self._parser.get_rulers():
             if r.name == name:
                 r.set_font_color(color)
-        self.render()
+        self.render_deferred()
 
     def toggle_ruler_label(self, name, plot_id, show_label, show_val_label):
         plot = self._get_plot_by_id(plot_id)
@@ -452,11 +452,13 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         if ruler:
             ruler.show_label = show_label
             ruler.show_val_label = show_val_label
-        for r in self._parser.get_rulers():
+        # Unlike visibility or colour, labels are decluttered per plot: each plot
+        # the ruler spans has its own row, so this stays on that plot alone.
+        for r in self._parser.get_rulers(self._get_impl_plot_for_plot(plot)):
             if r.name == name:
                 r.set_show_label(show_label)
                 r.set_show_val_label(show_val_label)
-        self.render()
+        self.render_deferred()
 
     def _add_ruler_at(self, impl_plot, plot, x: float, y: float,
                       name: str = None, color: str = None):
@@ -473,13 +475,13 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         self._preview_ruler_identity = None
         self._parser.add_ruler(impl_plot, name, x, y, ruler.color)
         self._parser.create_ruler_echoes(impl_plot, name, x_abs, y_abs, ruler.color)
-        is_date = bool(getattr(plot.axes[0], 'is_date', False))
-        plot_id = self._canvas_position_of(plot) or (1, 1)
         self._ruler_window.set_canvas_columns(len(self._parser.canvas.plots))
-        self._ruler_window.add_row(name, plot_id, (x_abs, y_abs), ruler.color,
-                                    visible=True, is_date=is_date,
-                                    signal_values=self._parser.ruler_signal_values_shared(impl_plot, x),
-                                    x_is_time=self._plot_x_is_time(plot))
+        with self._ruler_window.bulk_update():
+            for entry in self._ruler_window_rows(impl_plot, x, (x_abs, y_abs)):
+                self._ruler_window.add_row(name, entry['plot_id'], entry['xy'], ruler.color,
+                                            visible=True, is_date=entry['is_date'],
+                                            signal_values=entry['signal_values'],
+                                            x_is_time=entry['x_is_time'])
         if not self._ruler_window.isVisible():
             self._ruler_window.show()
         # Do not steal focus from the canvas.
@@ -503,6 +505,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             existing.refresh_labels()
             self._blit_preview()
             return
+        previous_background = self._preview_background
         self._clear_preview_ruler()
         ruler = self._parser.add_ruler(impl_plot, self._PREVIEW_RULER_NAME,
                                         x, y, ident['color'], animated=True)
@@ -512,7 +515,9 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         if self._preview_cid_draw is None:
             self._preview_cid_draw = self._mpl_renderer.mpl_connect(
                 'draw_event', self._on_draw_capture_bg)
-        self._preview_background = self._mpl_renderer.copy_from_bbox(
+        # Reuse the background when moving to another plot: capturing it again
+        # here would take in the ghost just drawn on the plot being left.
+        self._preview_background = previous_background or self._mpl_renderer.copy_from_bbox(
             self._parser.figure.bbox)
         self._blit_preview()
 
@@ -530,6 +535,19 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         for r in self._parser.get_rulers(self._preview_ruler_ax):
             if r.name == self._PREVIEW_RULER_NAME:
                 r.draw_artists()
+        self._mpl_renderer.blit(self._parser.figure.bbox)
+
+    def _erase_preview_ruler(self):
+        """Drop the ghost and paint over it from the blit background, which holds
+        the plots without it; redraw them only when there is no background."""
+        if self._preview_ruler_ax is None:
+            return
+        background = self._preview_background
+        self._clear_preview_ruler()
+        if background is None:
+            self._mpl_renderer.draw_idle()
+            return
+        self._mpl_renderer.restore_region(background)
         self._mpl_renderer.blit(self._parser.figure.bbox)
 
     def _clear_preview_ruler(self):
@@ -598,11 +616,12 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             return  # click without motion: nothing to persist
         origin = next((r for r in [ruler] + echoes if not r.is_echo), ruler)
         self._persist_ruler_position(origin)
-        self.render()
+        # The blit already shows the ruler where it was dropped.
+        self.render_deferred()
 
     def _persist_ruler_position(self, origin):
-        """Write an origin ruler's current (abs_x, y) to its model ruler and its
-        row in the Ruler window."""
+        """Write an origin ruler's current (abs_x, y) to its model ruler and to
+        its rows in the Ruler window, one per plot it spans."""
         ci = self._parser._impl_plot_cache_table.get_cache_item(origin.ax)
         origin_plot = ci.plot() if ci else None
         if origin_plot is None:
@@ -611,10 +630,8 @@ class QtMatplotlibCanvas(IplotQtCanvas):
         core = origin_plot.get_ruler(origin.name)
         if core is not None:
             core.xy = (x_abs, y_abs)
-        plot_id = self._canvas_position_of(origin_plot) or (1, 1)
-        self._ruler_window.update_row_xy(
-            origin.name, plot_id, (x_abs, y_abs),
-            signal_values=self._parser.ruler_signal_values_shared(origin.ax, origin.xy[0]))
+        self._ruler_window.update_ruler_rows(
+            origin.name, self._ruler_window_rows(origin.ax, origin.xy[0], (x_abs, y_abs)))
 
     def _find_ruler_near(self, impl_plot, event):
         rulers = self._parser.get_rulers(impl_plot)
@@ -658,30 +675,30 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             return
         self._ruler_window.set_canvas_columns(len(canvas.plots))
         added = False
-        for col_idx, col in enumerate(canvas.plots):
-            for row_idx, plot in enumerate(col):
-                if not plot or not getattr(plot, 'rulers', None):
-                    continue
-                impl_plot = self._get_impl_plot_for_plot(plot)
-                if impl_plot is None:
-                    continue
-                plot_id = (row_idx + 1, col_idx + 1)
-                is_date = bool(getattr(plot.axes[0], 'is_date', False))
-                for ruler in plot.rulers:
-                    x_view = self._parser.transform_value(impl_plot, 0, ruler.xy[0], inverse=True)
-                    y_view = self._parser.transform_value(impl_plot, 1, ruler.xy[1], inverse=True)
-                    self._parser.add_ruler(impl_plot, ruler.name, x_view, y_view, ruler.color)
-                    self._parser.create_ruler_echoes(impl_plot, ruler.name,
-                                                     ruler.xy[0], ruler.xy[1], ruler.color)
-                    self._ruler_window.add_row(ruler.name, plot_id, ruler.xy,
-                                                ruler.color, ruler.visible, is_date,
-                                                ruler.font_color, ruler.show_label,
-                                                ruler.show_val_label,
-                                                self._parser.ruler_signal_values_shared(impl_plot, x_view),
-                                                x_is_time=self._plot_x_is_time(plot))
-                    self._apply_ruler_state(ruler)
-                    added = True
-                self._ruler_window.count = max(self._ruler_window.count, len(plot.rulers))
+        with self._ruler_window.bulk_update():
+            for col_idx, col in enumerate(canvas.plots):
+                for row_idx, plot in enumerate(col):
+                    if not plot or not getattr(plot, 'rulers', None):
+                        continue
+                    impl_plot = self._get_impl_plot_for_plot(plot)
+                    if impl_plot is None:
+                        continue
+                    for ruler in plot.rulers:
+                        x_view = self._parser.transform_value(impl_plot, 0, ruler.xy[0], inverse=True)
+                        y_view = self._parser.transform_value(impl_plot, 1, ruler.xy[1], inverse=True)
+                        self._parser.add_ruler(impl_plot, ruler.name, x_view, y_view, ruler.color)
+                        self._parser.create_ruler_echoes(impl_plot, ruler.name,
+                                                         ruler.xy[0], ruler.xy[1], ruler.color)
+                        for entry in self._ruler_window_rows(impl_plot, x_view, ruler.xy):
+                            self._ruler_window.add_row(ruler.name, entry['plot_id'], entry['xy'],
+                                                        ruler.color, ruler.visible, entry['is_date'],
+                                                        ruler.font_color, ruler.show_label,
+                                                        ruler.show_val_label,
+                                                        entry['signal_values'],
+                                                        x_is_time=entry['x_is_time'])
+                        self._apply_ruler_state(ruler)
+                        added = True
+                    self._ruler_window.count = max(self._ruler_window.count, len(plot.rulers))
         # Only re-draw when rulers were actually restored.
         if added:
             self.render()
@@ -798,6 +815,11 @@ class QtMatplotlibCanvas(IplotQtCanvas):
     @Slot()
     def render(self):
         self._mpl_renderer.draw()
+
+    def render_deferred(self):
+        """Ask for a repaint instead of forcing one, so bursts of ruler changes
+        fold into a single draw of the canvas."""
+        self._mpl_renderer.draw_idle()
 
     def _flush_view(self):
         self.render()
@@ -951,9 +973,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             return
         if self._mmode == Canvas.MOUSE_MODE_RULER:
             if event.inaxes is None or event.xdata is None or event.ydata is None:
-                if self._preview_ruler_ax is not None:
-                    self._clear_preview_ruler()
-                    self._mpl_renderer.draw()
+                self._erase_preview_ruler()
                 return
             ci = self._parser._impl_plot_cache_table.get_cache_item(event.inaxes)
             plot = ci.plot() if hasattr(ci, 'plot') else None
@@ -962,9 +982,7 @@ class QtMatplotlibCanvas(IplotQtCanvas):
             # No ghost while hovering an existing ruler (a double-click there
             # grabs/ignores instead of creating).
             if self._find_ruler_near(event.inaxes, event) is not None:
-                if self._preview_ruler_ax is not None:
-                    self._clear_preview_ruler()
-                    self._mpl_renderer.draw()
+                self._erase_preview_ruler()
                 return
             self._show_preview_ruler(event.inaxes, event.xdata, event.ydata)
             return

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -1923,10 +1923,9 @@ class PyQtGraphParser(BackendParserBase):
                   color: str = "#FFFFFF", is_echo: bool = False) -> pyQtRuler:
         font_size = int(self._pm.get_value(self.canvas, 'font_size') or 8)
         ruler = pyQtRuler(plot=impl_plot, name=name, xy=(x, y), color=color, font_size=font_size,
-                          value_lines=self._ruler_value_lines(impl_plot))
+                          value_lines=self._ruler_value_lines(impl_plot), is_echo=is_echo)
         ruler.abs_x = self.transform_value(impl_plot, 0, x)
         ruler.abs_y = self.transform_value(impl_plot, 1, y)
-        ruler.is_echo = is_echo
         self._rulers.append(ruler)
         return ruler
 

--- a/iplotlib/impl/pyqtgraph/pyQtRuler.py
+++ b/iplotlib/impl/pyqtgraph/pyQtRuler.py
@@ -27,7 +27,8 @@ class pyQtRuler:
                  font_color: str = "#FFFFFF",
                  lw: int = 1,
                  font_size: int = 8,
-                 value_lines: List = None):
+                 value_lines: List = None,
+                 is_echo: bool = False):
         self.plot = plot
         self.name = name
         self.xy = xy
@@ -35,7 +36,7 @@ class pyQtRuler:
         # refresh so zoom/pan keep the ruler anchored to its data position.
         self.abs_x = xy[0]
         self.abs_y = xy[1]
-        self.is_echo = False
+        self.is_echo = is_echo
         self.color = color
         self.font_color = font_color
         self.visible = True
@@ -144,7 +145,9 @@ class pyQtRuler:
         # Inclusive bounds match the matplotlib backend (iplotMplRuler); bool()
         # because view range / xy may be numpy and setVisible rejects numpy.bool.
         in_x = bool(xmin <= x <= xmax)
-        in_y = bool(ymin <= y <= ymax)
+        # A mirrored copy carries the owner's Y against an unrelated scale, so it
+        # keeps the time line only.
+        in_y = bool(ymin <= y <= ymax) and not self.is_echo
         # Place the name on the opposite side of the vertical line from the value
         # label (which hangs toward the side with more room) so they never overlap.
         name_anchor_x = 1.0 if (x - xmin) < (xmax - x) else 0.0

--- a/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/qt/qtPyQtGraphCanvas.py
@@ -135,29 +135,29 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         if not canvas:
             return
         self._ruler_window.set_canvas_columns(len(canvas.plots))
-        for col_idx, col in enumerate(canvas.plots):
-            for row_idx, plot in enumerate(col):
-                if not plot or not getattr(plot, 'rulers', None):
-                    continue
-                impl_plot = self._get_impl_plot_for_plot(plot)
-                if impl_plot is None:
-                    continue
-                plot_id = (row_idx + 1, col_idx + 1)
-                is_date = bool(getattr(plot.axes[0], 'is_date', False))
-                for ruler in plot.rulers:
-                    x_view = self._parser.transform_value(impl_plot, 0, ruler.xy[0], inverse=True)
-                    y_view = self._parser.transform_value(impl_plot, 1, ruler.xy[1], inverse=True)
-                    self._parser.add_ruler(impl_plot, ruler.name, x_view, y_view, ruler.color)
-                    self._parser.create_ruler_echoes(impl_plot, ruler.name,
-                                                     ruler.xy[0], ruler.xy[1], ruler.color)
-                    self._ruler_window.add_row(ruler.name, plot_id, ruler.xy,
-                                                ruler.color, ruler.visible, is_date,
-                                                ruler.font_color, ruler.show_label,
-                                                ruler.show_val_label,
-                                                self._parser.ruler_signal_values_shared(impl_plot, x_view),
-                                                x_is_time=self._plot_x_is_time(plot))
-                    self._apply_ruler_state(ruler)
-                self._ruler_window.count = max(self._ruler_window.count, len(plot.rulers))
+        with self._ruler_window.bulk_update():
+            for col_idx, col in enumerate(canvas.plots):
+                for row_idx, plot in enumerate(col):
+                    if not plot or not getattr(plot, 'rulers', None):
+                        continue
+                    impl_plot = self._get_impl_plot_for_plot(plot)
+                    if impl_plot is None:
+                        continue
+                    for ruler in plot.rulers:
+                        x_view = self._parser.transform_value(impl_plot, 0, ruler.xy[0], inverse=True)
+                        y_view = self._parser.transform_value(impl_plot, 1, ruler.xy[1], inverse=True)
+                        self._parser.add_ruler(impl_plot, ruler.name, x_view, y_view, ruler.color)
+                        self._parser.create_ruler_echoes(impl_plot, ruler.name,
+                                                         ruler.xy[0], ruler.xy[1], ruler.color)
+                        for entry in self._ruler_window_rows(impl_plot, x_view, ruler.xy):
+                            self._ruler_window.add_row(ruler.name, entry['plot_id'], entry['xy'],
+                                                        ruler.color, ruler.visible, entry['is_date'],
+                                                        ruler.font_color, ruler.show_label,
+                                                        ruler.show_val_label,
+                                                        entry['signal_values'],
+                                                        x_is_time=entry['x_is_time'])
+                        self._apply_ruler_state(ruler)
+                    self._ruler_window.count = max(self._ruler_window.count, len(plot.rulers))
 
     def _get_main_plot_for_minimap(self) -> PlotItem:
         canvas = self.get_canvas()
@@ -602,7 +602,9 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         if ruler:
             ruler.show_label = show_label
             ruler.show_val_label = show_val_label
-        for r in self._parser.get_rulers():
+        # Unlike visibility or colour, labels are decluttered per plot: each plot
+        # the ruler spans has its own row, so this stays on that plot alone.
+        for r in self._parser.get_rulers(self._get_impl_plot_for_plot(plot)):
             if r.name == name:
                 r.set_show_label(show_label)
                 r.set_show_val_label(show_val_label)
@@ -622,13 +624,13 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         self._preview_ruler_identity = None
         self._parser.add_ruler(impl_plot, name, x, y, ruler.color)
         self._parser.create_ruler_echoes(impl_plot, name, x_abs, y_abs, ruler.color)
-        is_date = bool(getattr(plot.axes[0], 'is_date', False))
-        plot_id = self._canvas_position_of(plot) or (1, 1)
         self._ruler_window.set_canvas_columns(len(self._parser.canvas.plots))
-        self._ruler_window.add_row(name, plot_id, (x_abs, y_abs), ruler.color,
-                                    visible=True, is_date=is_date,
-                                    signal_values=self._parser.ruler_signal_values_shared(impl_plot, x),
-                                    x_is_time=self._plot_x_is_time(plot))
+        with self._ruler_window.bulk_update():
+            for entry in self._ruler_window_rows(impl_plot, x, (x_abs, y_abs)):
+                self._ruler_window.add_row(name, entry['plot_id'], entry['xy'], ruler.color,
+                                            visible=True, is_date=entry['is_date'],
+                                            signal_values=entry['signal_values'],
+                                            x_is_time=entry['x_is_time'])
         if not self._ruler_window.isVisible():
             self._ruler_window.show()
         # Do not steal focus from the canvas.
@@ -671,8 +673,8 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         self._persist_ruler_position(origin)
 
     def _persist_ruler_position(self, origin):
-        """Write an origin ruler's current (abs_x, y) to its model ruler and its
-        row in the Ruler window."""
+        """Write an origin ruler's current (abs_x, y) to its model ruler and to
+        its rows in the Ruler window, one per plot it spans."""
         ci = self._parser._impl_plot_cache_table.get_cache_item(origin.plot)
         origin_plot = ci.plot() if ci else None
         if origin_plot is None:
@@ -681,10 +683,8 @@ class QtPyQtGraphCanvas(IplotQtCanvas):
         core = origin_plot.get_ruler(origin.name)
         if core is not None:
             core.xy = (x_abs, y_abs)
-        plot_id = self._canvas_position_of(origin_plot) or (1, 1)
-        self._ruler_window.update_row_xy(
-            origin.name, plot_id, (x_abs, y_abs),
-            signal_values=self._parser.ruler_signal_values_shared(origin.plot, origin.xy[0]))
+        self._ruler_window.update_ruler_rows(
+            origin.name, self._ruler_window_rows(origin.plot, origin.xy[0], (x_abs, y_abs)))
 
     def _on_viewbox_resized(self, view_box):
         impl_plot = view_box.parentItem()

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -345,12 +345,33 @@ class IplotQtCanvas(QWidget):
                     return self._canvas_position_of(plot)
         return None
 
+    def _ruler_window_rows(self, impl_plot, x_view, xy_abs) -> List[dict]:
+        """One window row per plot a ruler placed on *impl_plot* is drawn on, each
+        with that plot's signal values and axis kind."""
+        rows = []
+        # ruler_reach yields the owner first: the mirrored plots share the time
+        # but not the Y scale, so only the owner carries a Y reading.
+        for index, (target, _, values) in enumerate(self._parser.ruler_reach(impl_plot, x_view)):
+            cache_item = self._parser._impl_plot_cache_table.get_cache_item(target)
+            plot = cache_item.plot() if cache_item else None
+            plot_id = self._canvas_position_of(plot) if plot is not None else None
+            if plot_id is None:
+                continue
+            rows.append({
+                'plot_id': plot_id,
+                'xy': xy_abs if index == 0 else (xy_abs[0], None),
+                'signal_values': values,
+                'is_date': bool(getattr(plot.axes[0], 'is_date', False)),
+                'x_is_time': self._plot_x_is_time(plot),
+            })
+        return rows
+
     def _remove_ruler_from_menu(self, name, plot_id):
         # The context menu can target a shared-x echo whose model ruler and
         # window row belong to another plot; route the deletion to the owner.
         plot_id = self._ruler_owner_plot_id(name) or plot_id
         self.delete_ruler(name, plot_id, True)
-        self._ruler_window.remove_row_by_name(name, plot_id)
+        self._ruler_window.remove_row_by_name(name)
 
     def _apply_ruler_state(self, ruler):
         """Push a model ruler's non-default state onto its backend artists

--- a/iplotlib/qt/gui/iplotQtRuler.py
+++ b/iplotlib/qt/gui/iplotQtRuler.py
@@ -1,5 +1,6 @@
 import csv
 import re
+from contextlib import contextmanager
 from string import ascii_uppercase
 from typing import Dict, List, Set, Tuple
 
@@ -8,8 +9,8 @@ from PySide6.QtCore import QEvent, Qt, QTimer, Signal
 from PySide6.QtGui import QAction, QBrush, QColor, QKeySequence, QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QButtonGroup, QCheckBox, QColorDialog, QComboBox,
                                 QDialog, QFileDialog, QFrame, QHBoxLayout, QHeaderView, QLabel, QMenu, QMessageBox,
-                                QPushButton, QRadioButton, QScrollArea, QStackedWidget, QTableWidget,
-                                QTableWidgetItem, QVBoxLayout, QWidget)
+                                QPushButton, QRadioButton, QScrollArea, QStackedWidget, QStyle,
+                                QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
 
 import iplotLogging.setupLogger as Sl
 from iplotlib.core.plot import PlotXY
@@ -66,6 +67,13 @@ class _CheckableComboBox(QComboBox):
         item.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
         self._update_text()
         self.changed.emit()
+
+    def showPopup(self):
+        # The popup is as wide as the field, which a narrow table column squeezes
+        # until the item text elides; its contents also need the check indicator.
+        view = self.view()
+        view.setMinimumWidth(view.sizeHintForColumn(0) + 2 * view.frameWidth())
+        super().showPopup()
 
     def eventFilter(self, obj, event):
         if obj is self.lineEdit() and event.type() == QEvent.Type.MouseButtonPress:
@@ -169,6 +177,7 @@ class IplotQtRuler(QWidget):
         self._sort_column = self.COL_NAME
         self._sort_order = Qt.SortOrder.AscendingOrder
         self._rendering = False
+        self._bulk_depth = 0
 
         self.rows_radio = QRadioButton("Rows")
         self.rows_radio.setToolTip("One row per ruler. Editable.")
@@ -276,30 +285,34 @@ class IplotQtRuler(QWidget):
         # Sorting must be off during insertion; re-render to handle both modes uniformly.
         self._render_table()
 
-    def remove_row_by_name(self, name: str, plot_id):
-        target = tuple(plot_id)
-        for i, row in enumerate(self._rows):
-            if row['name'] == name and row['plot_id'] == target:
-                del self._rows[i]
-                # A removed ruler can retire signal columns; re-render keeps the
-                # header set and the signals menu consistent. The rebuild drops
-                # the visual selection, so the history must go with it.
-                self.selection_history.clear()
-                self._render_table()
-                return
+    def remove_row_by_name(self, name: str):
+        """Drop every row of ruler *name*: a ruler drawn on several plots owns a
+        row per plot and is deleted as a whole."""
+        remaining = [r for r in self._rows if r['name'] != name]
+        if len(remaining) == len(self._rows):
+            return
+        self._rows = remaining
+        # A removed ruler can retire signal columns; re-render keeps the header
+        # set and the signals menu consistent. The rebuild drops the visual
+        # selection, so the history must go with it.
+        self.selection_history.clear()
+        self._render_table()
 
-    def update_row_xy(self, name: str, plot_id, xy: Tuple[float, float],
-                      signal_values: Dict[str, float] = None):
-        """Update a ruler row's (x, y) -- and its signal values, which change with
-        x -- after it is dragged on the canvas."""
-        target = tuple(plot_id)
+    def update_ruler_rows(self, name: str, rows: List[Dict]):
+        """Refresh ruler *name* after it is dragged on the canvas, from one
+        ``{'plot_id', 'xy', 'signal_values'}`` entry per plot it spans, so the
+        plots it is mirrored onto follow with their own values and not only the
+        one it was grabbed from."""
+        by_plot = {tuple(entry['plot_id']): entry for entry in rows}
         for row in self._rows:
-            if row['name'] == name and row['plot_id'] == target:
-                row['xy'] = (xy[0], xy[1])
-                if signal_values is not None:
-                    row['signal_values'] = dict(signal_values)
-                self._render_table()
-                return
+            if row['name'] != name:
+                continue
+            entry = by_plot.get(row['plot_id'])
+            if entry is None:
+                continue
+            row['xy'] = (entry['xy'][0], entry['xy'][1])
+            row['signal_values'] = dict(entry.get('signal_values') or {})
+        self._render_table()
 
     def clear_info(self):
         self._rows.clear()
@@ -333,8 +346,22 @@ class IplotQtRuler(QWidget):
         self._sort_column = column
         self._sort_order = order
 
+    @contextmanager
+    def bulk_update(self):
+        """Group several row changes into one rebuild: every change rebuilds the
+        whole view, and a ruler spanning N plots adds N rows."""
+        self._bulk_depth += 1
+        try:
+            yield
+        finally:
+            self._bulk_depth -= 1
+            if not self._bulk_depth:
+                self._render_table()
+
     def _render_table(self):
         """Rebuild the active view from ``self._rows``."""
+        if self._bulk_depth:
+            return
         # Rebuilding moves the sort indicator around; those moves are not the
         # user's choice and must not overwrite the remembered criterion.
         self._rendering = True
@@ -461,15 +488,17 @@ class IplotQtRuler(QWidget):
             self.table.insertRow(row_idx)
             self._populate_row_cells(row_idx, row)
 
-        self.table.resizeColumnsToContents()
-        # Add padding so the sort-indicator arrow does not clip the header text.
-        sort_arrow_pad = 24
-        for col in range(self.table.columnCount()):
-            self.table.setColumnWidth(col, self.table.columnWidth(col) + sort_arrow_pad)
         self.table.setSortingEnabled(True)
         column = self._sort_column if self._sort_column < self.table.columnCount() else self.COL_NAME
         self.table.sortItems(column, self._sort_order)
         self.table.horizontalHeader().setSortIndicator(column, self._sort_order)
+        self.table.resizeColumnsToContents()
+        # Fitting a column to its contents leaves its title no room for the sort
+        # indicator, which the header draws inside the section.
+        indicator = header.style().pixelMetric(QStyle.PixelMetric.PM_HeaderMarkSize, None, header)
+        for col in range(self.table.columnCount()):
+            self.table.setColumnWidth(col, max(self.table.columnWidth(col) + indicator,
+                                               header.defaultSectionSize()))
 
     def _populate_row_cells(self, row_idx: int, row: Dict):
         name_item = QTableWidgetItem(row['name'])
@@ -486,7 +515,7 @@ class IplotQtRuler(QWidget):
         x_item.setData(Qt.ItemDataRole.UserRole, x)
         self.table.setItem(row_idx, self.COL_X, x_item)
 
-        y_item = _NumericTableItem(f"{y:.6g}")
+        y_item = _NumericTableItem('' if y is None else f"{y:.6g}")
         y_item.setData(Qt.ItemDataRole.UserRole, y)
         self.table.setItem(row_idx, self.COL_Y, y_item)
 
@@ -577,13 +606,17 @@ class IplotQtRuler(QWidget):
         # One row per signal of this plot's rulers, in the global label order.
         sig_labels = [label for label in self._signal_labels
                       if any(label in (r.get('signal_values') or {}) for r in rulers)]
-        sig_rows = {label: len(self._COLUMNS_AXIS_LABELS) + i
+        # A plot the rulers are only mirrored onto has no Y reading of its own,
+        # so it drops the Y row instead of repeating the owner's value.
+        axis_labels = [label for label in self._COLUMNS_AXIS_LABELS
+                       if label != 'Y' or any(r['xy'][1] is not None for r in rulers)]
+        sig_rows = {label: len(axis_labels) + i
                     for i, label in enumerate(sig_labels)}
 
-        table = QTableWidget(len(self._COLUMNS_AXIS_LABELS) + len(sig_labels), col_count)
+        table = QTableWidget(len(axis_labels) + len(sig_labels), col_count)
         table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         table.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
-        table.setVerticalHeaderLabels(list(self._COLUMNS_AXIS_LABELS)
+        table.setVerticalHeaderLabels(axis_labels
                                       + [self._wrap_label(label) for label in sig_labels])
         for label, row_idx in sig_rows.items():
             table.verticalHeaderItem(row_idx).setToolTip(label)
@@ -599,6 +632,7 @@ class IplotQtRuler(QWidget):
         h_header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
         h_header.setStretchLastSection(False)
 
+        has_y = 'Y' in axis_labels
         col_idx = 0
         for i, r in enumerate(rulers):
             values = r.get('signal_values') or {}
@@ -606,14 +640,16 @@ class IplotQtRuler(QWidget):
                 prev = rulers[i - 1]
                 prev_values = prev.get('signal_values') or {}
                 self._set_plain_cell(table, 0, col_idx, self._format_consecutive_dx(prev, r))
-                self._set_plain_cell(table, 1, col_idx, f"{r['xy'][1] - prev['xy'][1]:.6g}")
+                if has_y:
+                    self._set_plain_cell(table, 1, col_idx,
+                                         self._format_delta(prev['xy'][1], r['xy'][1]))
                 for label, row_idx in sig_rows.items():
                     v1, v2 = prev_values.get(label), values.get(label)
-                    delta = f"{v2 - v1:.6g}" if v1 is not None and v2 is not None else ''
-                    self._set_plain_cell(table, row_idx, col_idx, delta)
+                    self._set_plain_cell(table, row_idx, col_idx, self._format_delta(v1, v2))
                 col_idx += 1
             self._set_axis_cell(table, 0, col_idx, self._format_x(r), r['color'])
-            self._set_axis_cell(table, 1, col_idx, f"{r['xy'][1]:.6g}", r['color'])
+            if has_y:
+                self._set_axis_cell(table, 1, col_idx, f"{r['xy'][1]:.6g}", r['color'])
             for label, row_idx in sig_rows.items():
                 value = values.get(label)
                 self._set_axis_cell(table, row_idx, col_idx,
@@ -680,6 +716,13 @@ class IplotQtRuler(QWidget):
     def _format_x(row: Dict) -> str:
         x = row['xy'][0]
         return str(pd.Timestamp(x)) if row['is_date'] else f"{x:.6g}"
+
+    @staticmethod
+    def _format_delta(first, second) -> str:
+        """Signed difference, blank when either side has no reading."""
+        if first is None or second is None:
+            return ''
+        return f"{second - first:.6g}"
 
     @staticmethod
     def _set_axis_cell(table: QTableWidget, axis_row: int, col_idx: int, text: str, color: str):
@@ -795,7 +838,7 @@ class IplotQtRuler(QWidget):
                                    for label in self._signal_labels]
                     writer.writerow([
                         r['name'], self._format_plot_id(r['plot_id']), self._format_x(r),
-                        f"{r['xy'][1]:.6g}", *value_cells,
+                        '' if r['xy'][1] is None else f"{r['xy'][1]:.6g}", *value_cells,
                         str(r['visible']).lower(), self._labels_summary(r),
                         r['color'], r['font_color'],
                     ])
@@ -835,9 +878,10 @@ class IplotQtRuler(QWidget):
     def _on_visibility_changed(self, row: int, state):
         visible = state == Qt.CheckState.Checked.value
         name, plot_id = self._row_metadata(row)
-        idx = self._find_row_index(name, plot_id)
-        if idx >= 0:
-            self._rows[idx]['visible'] = visible
+        # Visibility belongs to the ruler, not to one of the plots it spans.
+        for r in self._rows:
+            if r['name'] == name:
+                r['visible'] = visible
         self.visibilityRuler.emit(name, plot_id, visible)
 
     def _on_label_mode_changed(self, row: int, combo: '_CheckableComboBox'):
@@ -863,19 +907,23 @@ class IplotQtRuler(QWidget):
         color = new_color.name()
         self._paint_color_button(button, color)
         name, plot_id = self._row_metadata(row)
-        idx = self._find_row_index(name, plot_id)
-        if idx >= 0:
-            self._rows[idx][key] = color
+        # Colours belong to the ruler, so they reach every plot it spans.
+        for r in self._rows:
+            if r['name'] == name:
+                r[key] = color
         signal.emit(name, plot_id, color)
 
     def _remove_selected(self):
         # Resolve identities BEFORE deletion so visual rows stay valid until we drop them.
         identities = [self._row_metadata(row) for row in self.selection_history]
+        removed: Set[str] = set()
         for name, plot_id in identities:
+            # Selecting two rows of the same ruler must delete it once.
+            if name in removed:
+                continue
+            removed.add(name)
             self.deleteRuler.emit(name, plot_id, True)
-            idx = self._find_row_index(name, plot_id)
-            if idx >= 0:
-                del self._rows[idx]
+        self._rows = [r for r in self._rows if r['name'] not in removed]
         self.selection_history.clear()
         self._render_table()
 
@@ -901,10 +949,11 @@ class IplotQtRuler(QWidget):
 
         data_rows = []
         for r1, r2 in zip(entries[:-1], entries[1:]):
+            y1, y2 = r1['xy'][1], r2['xy'][1]
             cells = [f"{r1['name']} → {r2['name']}",
                      self._format_dx(r1['xy'][0], r2['xy'][0], r1['is_date'],
                                      r1.get('x_is_time', False)),
-                     f"{abs(r2['xy'][1] - r1['xy'][1]):.6g}"]
+                     '' if y1 is None or y2 is None else f"{abs(y2 - y1):.6g}"]
             values1 = r1.get('signal_values') or {}
             values2 = r2.get('signal_values') or {}
             for label in sig_labels:

--- a/iplotlib/standalone/tests/test_ruler_matplotlib.py
+++ b/iplotlib/standalone/tests/test_ruler_matplotlib.py
@@ -78,7 +78,7 @@ class RulerMatplotlibEndToEndTest(unittest.TestCase):
         self.widget._add_ruler_at(self.impl_plot, self.plot, 1.0, 0.1)
         self.widget._add_ruler_at(self.impl_plot, self.plot, 3.0, 0.3)
         self.widget.delete_ruler('A', (self.plot.col, self.plot.row), True)
-        self.widget._ruler_window.remove_row_by_name('A', (self.plot.col, self.plot.row))
+        self.widget._ruler_window.remove_row_by_name('A')
         self.assertEqual([r.name for r in self.plot.rulers], ['B'])
         self.assertEqual([r.name for r in self.widget._parser.get_rulers(self.impl_plot)], ['B'])
         self.assertEqual(self.widget._ruler_window.table.rowCount(), 1)
@@ -154,6 +154,17 @@ class RulerMatplotlibEndToEndTest(unittest.TestCase):
         self.assertEqual(self.plot.rulers, [])
         self.assertEqual(self.widget._ruler_window.table.rowCount(), 0)
 
+    def test_erasing_the_preview_reuses_the_blit_background(self):
+        """Hopping between plots crosses the gap between axes, where the ghost is
+        dropped: it must go without redrawing every plot."""
+        self.widget._show_preview_ruler(self.impl_plot, 2.0, 0.2)
+        draws = []
+        self.widget._mpl_renderer.draw = lambda *a, **k: draws.append(1)
+        self.widget._erase_preview_ruler()
+        self.assertIsNone(self.widget._preview_ruler_ax)
+        self.assertEqual(self.widget._parser.get_rulers(self.impl_plot), [])
+        self.assertEqual(draws, [])
+
     def test_add_ruler_clears_preview_and_takes_its_identity(self):
         self.widget._show_preview_ruler(self.impl_plot, 2.0, 0.2)
         self.widget._add_ruler_at(self.impl_plot, self.plot, 2.0, 0.2)
@@ -164,7 +175,7 @@ class RulerMatplotlibEndToEndTest(unittest.TestCase):
         self.widget._add_ruler_at(self.impl_plot, self.plot, 1.0, 0.1)
         self.widget._add_ruler_at(self.impl_plot, self.plot, 3.0, 0.3)
         self.widget.delete_ruler('A', (self.plot.col, self.plot.row), True)
-        self.widget._ruler_window.remove_row_by_name('A', (self.plot.col, self.plot.row))
+        self.widget._ruler_window.remove_row_by_name('A')
         self.assertEqual(self.widget._preview_identity_for_next()['name'], 'A')
 
     def test_remove_from_menu_on_shared_x_echo_deletes_the_owner_ruler(self):
@@ -200,11 +211,76 @@ class RulerMatplotlibEndToEndTest(unittest.TestCase):
             widget._ruler_window.close()
             widget.deleteLater()
 
-    def test_shared_x_row_carries_signal_values_of_every_shared_plot(self):
-        """With a shared time axis the ruler's row must also carry the values of
-        the sibling plots' signals (what its echoes display), so cross-plot
-        deltas can be computed; without shared time only its own plot counts."""
-        for shared, expected_labels in ((True, {'s1', 's2'}), (False, {'s1'})):
+    def test_mirrored_plots_show_no_y_reading(self):
+        """The Y value belongs to the plot the ruler was placed on: the plots it
+        is mirrored onto share the time but not the Y scale, so neither the canvas
+        nor the window may repeat it there."""
+        c = Canvas(2, 1, title="mirror_y_mpl", shared_x_axis=True)
+        x = np.linspace(0, 10, 50)
+        for scale in (1.0, 1000.0):
+            p = PlotXY()
+            s = SignalXY(label=f"s{scale:.0f}")
+            s.set_data([x, scale * np.sin(x)])
+            p.add_signal(s)
+            c.add_plot(p, 0)
+        widget = QtMatplotlibCanvas(canvas=c)
+        try:
+            plot_one, plot_two = c.plots[0]
+            impl_one = widget._get_impl_plot_for_plot(plot_one)
+            impl_two = widget._get_impl_plot_for_plot(plot_two)
+            widget._add_ruler_at(impl_one, plot_one, 5.0, 0.5)
+
+            rows = {r['plot_id']: r for r in widget._ruler_window._rows}
+            self.assertIsNotNone(rows[(1, 1)]['xy'][1])
+            self.assertIsNone(rows[(2, 1)]['xy'][1])
+
+            owner = widget._parser.get_rulers(impl_one)[0]
+            mirror = widget._parser.get_rulers(impl_two)[0]
+            self.assertTrue(owner.y_label.get_visible())
+            self.assertTrue(owner.h_line.get_visible())
+            self.assertFalse(mirror.y_label.get_visible())
+            self.assertFalse(mirror.h_line.get_visible())
+            # The time line still reaches the mirrored plot.
+            self.assertTrue(mirror.v_line.get_visible())
+        finally:
+            widget._ruler_window.close()
+            widget.deleteLater()
+
+    def test_label_toggle_only_reaches_the_plot_of_its_row(self):
+        """Each plot the ruler spans owns a row, so hiding its labels there must
+        leave the same ruler's labels on the other shared plots untouched."""
+        c = Canvas(2, 1, title="labels_per_plot_mpl", shared_x_axis=True)
+        x = np.linspace(0, 10, 50)
+        for _ in range(2):
+            p = PlotXY()
+            s = SignalXY(label="s")
+            s.set_data([x, np.sin(x)])
+            p.add_signal(s)
+            c.add_plot(p, 0)
+        widget = QtMatplotlibCanvas(canvas=c)
+        try:
+            plot_one, plot_two = c.plots[0]
+            impl_one = widget._get_impl_plot_for_plot(plot_one)
+            impl_two = widget._get_impl_plot_for_plot(plot_two)
+            widget._add_ruler_at(impl_one, plot_one, 5.0, 0.0)
+
+            widget.toggle_ruler_label('A', (1, 1), False, False)
+
+            own = widget._parser.get_rulers(impl_one)[0]
+            other = widget._parser.get_rulers(impl_two)[0]
+            self.assertFalse(own.show_label)
+            self.assertFalse(own.show_val_label)
+            self.assertTrue(other.show_label)
+            self.assertTrue(other.show_val_label)
+        finally:
+            widget._ruler_window.close()
+            widget.deleteLater()
+
+    def test_shared_x_gives_the_ruler_a_row_per_plot_with_that_plot_values(self):
+        """With a shared time axis the ruler is drawn on every shared plot, so the
+        window lists one row per plot, each carrying only the values of the signals
+        that plot holds; without shared time only its own plot is listed."""
+        for shared, expected in ((True, {(1, 1): 's1', (2, 1): 's2'}), (False, {(1, 1): 's1'})):
             c = Canvas(2, 1, title="shared_vals_mpl", shared_x_axis=shared)
             x = np.linspace(0, 10, 50)
             for i, y in enumerate((np.sin(x), np.cos(x))):
@@ -220,12 +296,20 @@ class RulerMatplotlibEndToEndTest(unittest.TestCase):
                 # 5.05 sits unambiguously nearest to one sample; 5.0 would
                 # tie between two and argmin breaks the tie unlike the backends.
                 widget._add_ruler_at(impl_one, plot_one, 5.05, 0.0)
-                values = widget._ruler_window._rows[0]['signal_values']
-                self.assertEqual(set(values), expected_labels, msg=f"shared={shared}")
+                rows = {r['plot_id']: r for r in widget._ruler_window._rows}
+                self.assertEqual(set(rows), set(expected), msg=f"shared={shared}")
                 nearest = int(np.argmin(np.abs(x - 5.05)))
-                self.assertAlmostEqual(values['s1'], np.sin(x)[nearest])
-                if shared:
-                    self.assertAlmostEqual(values['s2'], np.cos(x)[nearest])
+                expected_y = {'s1': np.sin(x)[nearest], 's2': np.cos(x)[nearest]}
+                for plot_id, label in expected.items():
+                    values = rows[plot_id]['signal_values']
+                    self.assertEqual(set(values), {label}, msg=f"shared={shared}")
+                    self.assertAlmostEqual(values[label], expected_y[label])
+                # Every row sits at the same instant, but only the plot the ruler
+                # was placed on has a Y reading of its own.
+                rows_list = widget._ruler_window._rows
+                self.assertEqual({r['xy'][0] for r in rows_list}, {rows_list[0]['xy'][0]})
+                with_y = {r['plot_id'] for r in rows_list if r['xy'][1] is not None}
+                self.assertEqual(with_y, {(1, 1)}, msg=f"shared={shared}")
             finally:
                 widget._ruler_window.close()
                 widget.deleteLater()

--- a/iplotlib/standalone/tests/test_ruler_pyqtgraph.py
+++ b/iplotlib/standalone/tests/test_ruler_pyqtgraph.py
@@ -84,7 +84,7 @@ class RulerPyQtGraphEndToEndTest(unittest.TestCase):
         self.widget._add_ruler_at(self.impl_plot, self.plot, 3.0, 0.3)
 
         self.widget.delete_ruler('A', (self.plot.col, self.plot.row), True)
-        self.widget._ruler_window.remove_row_by_name('A', (self.plot.col, self.plot.row))
+        self.widget._ruler_window.remove_row_by_name('A')
 
         self.assertEqual([r.name for r in self.plot.rulers], ['B'])
         self.assertEqual([r.name for r in self.widget._parser.get_rulers(self.impl_plot)], ['B'])
@@ -174,7 +174,7 @@ class RulerPyQtGraphEndToEndTest(unittest.TestCase):
         self.widget._add_ruler_at(self.impl_plot, self.plot, 1.0, 0.1)
         self.widget._add_ruler_at(self.impl_plot, self.plot, 3.0, 0.3)
         self.widget.delete_ruler('A', (self.plot.col, self.plot.row), True)
-        self.widget._ruler_window.remove_row_by_name('A', (self.plot.col, self.plot.row))
+        self.widget._ruler_window.remove_row_by_name('A')
         self.assertEqual(self.widget._preview_identity_for_next()['name'], 'A')
 
     def test_remove_from_menu_on_shared_x_echo_deletes_the_owner_ruler(self):
@@ -210,11 +210,76 @@ class RulerPyQtGraphEndToEndTest(unittest.TestCase):
             widget._ruler_window.close()
             widget.deleteLater()
 
-    def test_shared_x_row_carries_signal_values_of_every_shared_plot(self):
-        """With a shared time axis the ruler's row must also carry the values of
-        the sibling plots' signals (what its echoes display), so cross-plot
-        deltas can be computed; without shared time only its own plot counts."""
-        for shared, expected_labels in ((True, {'s1', 's2'}), (False, {'s1'})):
+    def test_mirrored_plots_show_no_y_reading(self):
+        """The Y value belongs to the plot the ruler was placed on: the plots it
+        is mirrored onto share the time but not the Y scale, so neither the canvas
+        nor the window may repeat it there."""
+        c = Canvas(2, 1, title="mirror_y_pg", shared_x_axis=True)
+        x = np.linspace(0, 10, 50)
+        for scale in (1.0, 1000.0):
+            p = PlotXY()
+            s = SignalXY(label=f"s{scale:.0f}")
+            s.set_data([x, scale * np.sin(x)])
+            p.add_signal(s)
+            c.add_plot(p, 0)
+        widget = QtPyQtGraphCanvas(canvas=c)
+        try:
+            plot_one, plot_two = c.plots[0]
+            impl_one = widget._get_impl_plot_for_plot(plot_one)
+            impl_two = widget._get_impl_plot_for_plot(plot_two)
+            widget._add_ruler_at(impl_one, plot_one, 5.0, 0.5)
+
+            rows = {r['plot_id']: r for r in widget._ruler_window._rows}
+            self.assertIsNotNone(rows[(1, 1)]['xy'][1])
+            self.assertIsNone(rows[(2, 1)]['xy'][1])
+
+            owner = widget._parser.get_rulers(impl_one)[0]
+            mirror = widget._parser.get_rulers(impl_two)[0]
+            self.assertTrue(owner.y_label.isVisible())
+            self.assertTrue(owner.h_line.isVisible())
+            self.assertFalse(mirror.y_label.isVisible())
+            self.assertFalse(mirror.h_line.isVisible())
+            # The time line still reaches the mirrored plot.
+            self.assertTrue(mirror.v_line.isVisible())
+        finally:
+            widget._ruler_window.close()
+            widget.deleteLater()
+
+    def test_label_toggle_only_reaches_the_plot_of_its_row(self):
+        """Each plot the ruler spans owns a row, so hiding its labels there must
+        leave the same ruler's labels on the other shared plots untouched."""
+        c = Canvas(2, 1, title="labels_per_plot_pg", shared_x_axis=True)
+        x = np.linspace(0, 10, 50)
+        for _ in range(2):
+            p = PlotXY()
+            s = SignalXY(label="s")
+            s.set_data([x, np.sin(x)])
+            p.add_signal(s)
+            c.add_plot(p, 0)
+        widget = QtPyQtGraphCanvas(canvas=c)
+        try:
+            plot_one, plot_two = c.plots[0]
+            impl_one = widget._get_impl_plot_for_plot(plot_one)
+            impl_two = widget._get_impl_plot_for_plot(plot_two)
+            widget._add_ruler_at(impl_one, plot_one, 5.0, 0.0)
+
+            widget.toggle_ruler_label('A', (1, 1), False, False)
+
+            own = widget._parser.get_rulers(impl_one)[0]
+            other = widget._parser.get_rulers(impl_two)[0]
+            self.assertFalse(own.show_label)
+            self.assertFalse(own.show_val_label)
+            self.assertTrue(other.show_label)
+            self.assertTrue(other.show_val_label)
+        finally:
+            widget._ruler_window.close()
+            widget.deleteLater()
+
+    def test_shared_x_gives_the_ruler_a_row_per_plot_with_that_plot_values(self):
+        """With a shared time axis the ruler is drawn on every shared plot, so the
+        window lists one row per plot, each carrying only the values of the signals
+        that plot holds; without shared time only its own plot is listed."""
+        for shared, expected in ((True, {(1, 1): 's1', (2, 1): 's2'}), (False, {(1, 1): 's1'})):
             c = Canvas(2, 1, title="shared_vals_pg", shared_x_axis=shared)
             x = np.linspace(0, 10, 50)
             for i, y in enumerate((np.sin(x), np.cos(x))):
@@ -230,12 +295,20 @@ class RulerPyQtGraphEndToEndTest(unittest.TestCase):
                 # 5.05 sits unambiguously nearest to one sample; 5.0 would
                 # tie between two and argmin breaks the tie unlike the backends.
                 widget._add_ruler_at(impl_one, plot_one, 5.05, 0.0)
-                values = widget._ruler_window._rows[0]['signal_values']
-                self.assertEqual(set(values), expected_labels, msg=f"shared={shared}")
+                rows = {r['plot_id']: r for r in widget._ruler_window._rows}
+                self.assertEqual(set(rows), set(expected), msg=f"shared={shared}")
                 nearest = int(np.argmin(np.abs(x - 5.05)))
-                self.assertAlmostEqual(values['s1'], np.sin(x)[nearest])
-                if shared:
-                    self.assertAlmostEqual(values['s2'], np.cos(x)[nearest])
+                expected_y = {'s1': np.sin(x)[nearest], 's2': np.cos(x)[nearest]}
+                for plot_id, label in expected.items():
+                    values = rows[plot_id]['signal_values']
+                    self.assertEqual(set(values), {label}, msg=f"shared={shared}")
+                    self.assertAlmostEqual(values[label], expected_y[label])
+                # Every row sits at the same instant, but only the plot the ruler
+                # was placed on has a Y reading of its own.
+                rows_list = widget._ruler_window._rows
+                self.assertEqual({r['xy'][0] for r in rows_list}, {rows_list[0]['xy'][0]})
+                with_y = {r['plot_id'] for r in rows_list if r['xy'][1] is not None}
+                self.assertEqual(with_y, {(1, 1)}, msg=f"shared={shared}")
             finally:
                 widget._ruler_window.close()
                 widget.deleteLater()

--- a/iplotlib/standalone/tests/test_ruler_window.py
+++ b/iplotlib/standalone/tests/test_ruler_window.py
@@ -53,7 +53,7 @@ class IplotQtRulerWindowTest(unittest.TestCase):
         for _ in range(3):
             n = self.window.next_name()
             self.window.add_row(n, (1, 1), (0.0, 0.0), '#FFFFFF')
-        self.window.remove_row_by_name('B', (1, 1))
+        self.window.remove_row_by_name('B')
         self.assertEqual(self.window.next_name(), 'B')
 
     def test_next_color_is_stable_per_letter(self):
@@ -63,12 +63,29 @@ class IplotQtRulerWindowTest(unittest.TestCase):
         self.assertEqual(self.window.next_color('J'), palette[9])
         self.assertEqual(self.window.next_color('A'), palette[0])
 
-    def test_remove_row_by_name_finds_matching_plot(self):
+    def test_remove_row_by_name_drops_every_plot_the_ruler_spans(self):
+        """A ruler drawn on several plots owns one row per plot and is deleted as
+        a whole, so removing it must leave no orphan row behind."""
         self.window.add_row('A', (1, 1), (1.0, 2.0), '#FFFFFF')
-        self.window.add_row('A', (2, 1), (3.0, 4.0), '#FFFFFF')
-        self.window.remove_row_by_name('A', (1, 1))
+        self.window.add_row('A', (2, 1), (1.0, 2.0), '#FFFFFF')
+        self.window.add_row('B', (1, 1), (3.0, 4.0), '#FFFFFF')
+        self.window.remove_row_by_name('A')
         self.assertEqual(self.window.table.rowCount(), 1)
-        self.assertEqual(self.window.table.item(0, IplotQtRuler.COL_PLOT).text(), '2')
+        self.assertEqual(self.window.table.item(0, IplotQtRuler.COL_NAME).text(), 'B')
+
+    def test_bulk_update_rebuilds_the_view_once(self):
+        """Each row change rebuilds the whole view, so the rows of a ruler that
+        spans several plots must be added inside one bulk update."""
+        rebuilds = []
+        original = self.window._rebuild_view
+        self.window._rebuild_view = lambda: (rebuilds.append(None), original())[1]
+
+        with self.window.bulk_update():
+            for plot_id in ((1, 1), (2, 1), (3, 1), (4, 1)):
+                self.window.add_row('A', plot_id, (1.0, 2.0), '#FFFFFF')
+
+        self.assertEqual(len(rebuilds), 1)
+        self.assertEqual(self.window.table.rowCount(), 4)
 
     def test_plot_id_drops_column_suffix_for_single_column_canvas(self):
         self.window.set_canvas_columns(1)
@@ -186,9 +203,10 @@ class IplotQtRulerWindowTest(unittest.TestCase):
         self.assertEqual(item.text().replace('\n', ''), long_name)
         self.assertEqual(item.toolTip(), long_name)
 
-    def test_update_row_xy_refreshes_signal_values(self):
+    def test_update_ruler_rows_refreshes_signal_values(self):
         self.window.add_row('A', (1, 1), (2.5, 7.5), '#FFFFFF', signal_values={'VAR1': 1.0})
-        self.window.update_row_xy('A', (1, 1), (3.0, 8.0), signal_values={'VAR1': 2.0})
+        self.window.update_ruler_rows('A', [{'plot_id': (1, 1), 'xy': (3.0, 8.0),
+                                             'signal_values': {'VAR1': 2.0}}])
         self.assertEqual(self.window._rows[0]['signal_values'], {'VAR1': 2.0})
         self.assertEqual(
             self.window.table.item(0, IplotQtRuler.SIG_COL_BASE).text(), '2')
@@ -375,7 +393,7 @@ class IplotQtRulerViewModeTest(unittest.TestCase):
         self.assertEqual(copied, '1\t2\t3\n2\t2\t4')
 
     def test_singleton_plot_section_has_no_delta_column(self):
-        self.window.remove_row_by_name('B', (1, 1))
+        self.window.remove_row_by_name('B')
         self.window.columns_radio.setChecked(True)
         _, table, _ = self.window.column_sections[0]
         self.assertEqual(table.columnCount(), 1)
@@ -515,7 +533,7 @@ class RulerSortPersistenceTest(unittest.TestCase):
         self.window.table.sortByColumn(IplotQtRuler.COL_X, Qt.SortOrder.AscendingOrder)
         self.assertEqual(self._names(), ['A', 'C', 'B'])
 
-        self.window.update_row_xy('B', (2, 1), (9.0, 1.0))
+        self.window.update_ruler_rows('B', [{'plot_id': (2, 1), 'xy': (9.0, 1.0)}])
 
         self.assertEqual(self._names(), ['A', 'C', 'B'])
         header = self.window.table.horizontalHeader()
@@ -531,6 +549,16 @@ class RulerSortPersistenceTest(unittest.TestCase):
 
     def test_default_sort_is_by_ruler_name(self):
         self.assertEqual(self._names(), ['A', 'B', 'C'])
+
+    def test_columns_leave_room_for_the_sort_indicator(self):
+        """The arrow is drawn inside the section, so a column fitted to its
+        contents alone loses part of its title once sorted by that column."""
+        table = self.window.table
+        header = table.horizontalHeader()
+        self.assertTrue(header.isSortIndicatorShown())
+        narrow = [col for col in range(table.columnCount())
+                  if table.columnWidth(col) < header.defaultSectionSize()]
+        self.assertEqual(narrow, [])
 
 
 class RulerComputeDistanceDialogTest(unittest.TestCase):


### PR DESCRIPTION
With a shared time axis a ruler is drawn on all the shared plots, but the window only listed the plot it was created on, and merged every plot's signal values into one row.

- One row per plot, each with that plot's own signal values.
- The Y reading stays on the plot the ruler was placed on: the mirrored copies share the time, not the Y scale, so they drop the horizontal line and the Y cell.
- Labels are toggled per plot, like the row they belong to; visibility and colours still apply to the whole ruler.
- Group the rows of a ruler into one table rebuild, and defer the canvas repaint after a property change instead of forcing it.
- Erase the ruler ghost from the blit background rather than redrawing every plot when the pointer crosses between plots.
- Leave room for the sort indicator in the column headers, and size the Labels popup to its own contents.