### PR TITLE
Keep the shared time group together across focus (#153)

### DIFF
--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -766,7 +766,12 @@ class BackendParserBase(ABC):
 
     @staticmethod
     def _plot_signal_ts_range(plot):
-        """(ts_start, ts_end) of the first numeric-valued signal on ``plot``, or None."""
+        """(ts_start, ts_end) of the first numeric-valued signal on ``plot``, or None.
+
+        Returned as floats: a range restored from the axis 'original' is an exact
+        integer while one that has been through the backend comes back as float64,
+        which past 2**53 cannot hold a nanosecond, and both name the same window.
+        """
         if plot is None or not plot.signals:
             return None
         for stack in plot.signals.values():
@@ -776,7 +781,7 @@ class BackendParserBase(ABC):
                 ts_start = getattr(signal, 'ts_start', None)
                 ts_end = getattr(signal, 'ts_end', None)
                 if isinstance(ts_start, (int, float)) and isinstance(ts_end, (int, float)):
-                    return (ts_start, ts_end)
+                    return (float(ts_start), float(ts_end))
         return None
 
     @staticmethod

--- a/iplotlib/core/impl_base.py
+++ b/iplotlib/core/impl_base.py
@@ -935,6 +935,43 @@ class BackendParserBase(ABC):
 
         return shared
 
+    def _carry_focus_window_to_hidden_plots(self):
+        """
+        Carry the focused plot's time window to the plots the focus hid.
+
+        Focus builds only the focused plot, so a zoom made there leaves the others
+        behind. Window and signal ts go to their model, which the rebuild on unfocus
+        draws from. Membership is decided on the draw-time window, the only range a
+        zoom in focus leaves untouched.
+        """
+        if not isinstance(self.canvas, Canvas) or not self._pm.get_value(self.canvas, 'shared_x_axis'):
+            return
+        focused = self._focus_plot
+        if focused is None or isinstance(focused, (PlotXYWithSlider, PlotContourWithSlider)):
+            return
+        if not focused.axes or not isinstance(focused.axes[0], RangeAxis):
+            return
+        begin, end = focused.axes[0].get_limits('current')
+        if begin is None or end is None:
+            return
+        drawn = focused.axes[0].get_limits('original')
+
+        for column in self.canvas.plots:
+            for plot in column or []:
+                if plot is None or plot is focused:
+                    continue
+                if isinstance(plot, (PlotXYWithSlider, PlotContourWithSlider)):
+                    continue
+                if not plot.axes or not isinstance(plot.axes[0], RangeAxis):
+                    continue
+                if plot.axes[0].get_limits('original') != drawn:
+                    continue
+                logger.debug(f"Carrying focus window [{begin}, {end}] to plot {id(plot)}")
+                plot.axes[0].set_limits(begin, end, 'current')
+                for stack in plot.signals.values():
+                    for signal in stack:
+                        signal.set_limits((begin, end))
+
     def _ruler_signal_values(self, impl_plot: Any, x: float) -> Dict[str, float]:
         """Value of each signal at the ruler X keyed by its label. Backends with
         ruler support override this; the base has no per-signal resolution."""
@@ -1785,7 +1822,14 @@ class BackendParserBase(ABC):
 
     @abstractmethod
     def set_focus_plot(self, impl_plot: Any):
-        """Sets the focus plot."""
+        """
+        Sets the focus plot.
+
+        Implementations must call this before reassigning :attr:`_focus_plot`: leaving
+        focus carries the focused plot's window to the plots it hid.
+        """
+        if self._focus_plot is not None:
+            self._carry_focus_window_to_hidden_plots()
 
     def undo(self):
         """
@@ -2046,9 +2090,15 @@ class BackendParserBase(ABC):
         # the offset-relative signal data does not run and the data stays drawn
         # at the old offset. Detect that around the X set so the re-plot below
         # can compensate.
-        x_before = self.get_impl_x_axis_limits(impl_plot) if impl_plot is not None else None
-        self.set_oaw_axis_limits(impl_plot, 0, (ax_limits[0].begin, ax_limits[0].end))
-        x_view_moved = impl_plot is not None and self.get_impl_x_axis_limits(impl_plot) != x_before
+        has_impl = impl_plot is not None
+        x_before = self.get_impl_x_axis_limits(impl_plot) if has_impl else None
+        if has_impl:
+            self.set_oaw_axis_limits(impl_plot, 0, (ax_limits[0].begin, ax_limits[0].end))
+        else:
+            # A plot hidden by the focus has no implementation plot to set: the ranges
+            # go to its model, which the rebuild on unfocus draws from.
+            self._set_model_plot_limits(plot, ax_limits, signal_limits)
+        x_view_moved = has_impl and self.get_impl_x_axis_limits(impl_plot) != x_before
         # isinstance(plot, PlotXYWithSlider): TODO: test with Slider
 
         # Restore the exact recorded signal-level xrange values.
@@ -2057,12 +2107,13 @@ class BackendParserBase(ABC):
             signal.set_xranges(signal_limit.get_limits())
 
         # Set Y limits
-        self.set_oaw_axis_limits(impl_plot, 1, (ax_limits[1].begin, ax_limits[1].end))
+        if has_impl:
+            self.set_oaw_axis_limits(impl_plot, 1, (ax_limits[1].begin, ax_limits[1].end))
         # isinstance(plot, PlotXYWithSlider): TODO: test with Slider
 
         # Only when the view did not move (so the callback did not re-plot) do we
         # re-plot here, at the restored offset. matplotlib moves the view -> skipped.
-        if impl_plot is not None and not x_view_moved:
+        if has_impl and not x_view_moved:
             for signal_ref in self._impl_plot_cache_table.get_cache_item(impl_plot).signals:
                 signal = signal_ref()
                 if signal is not None:
@@ -2071,6 +2122,27 @@ class BackendParserBase(ABC):
         # Restore slider-specific limits, if the plot has one
         if isinstance(plot, PlotXYWithSlider) and self._pm.get_value(self.canvas, 'shared_x_axis'):
             self.set_impl_plot_slider_limits(plot, *limits.sliders_ranges[0].get_limits())
+
+    def _set_model_plot_limits(self, plot, ax_limits, signal_limits):
+        """
+        Apply recorded ranges to a plot that has no implementation plot to set them on.
+
+        The Y range has to come along or the plot comes back from focus keeping the
+        zoomed one. Only the stack the recorded signals belong to is touched, since a
+        stacked plot holds one Y axis per stack.
+        """
+        if plot is None or not plot.axes or len(ax_limits) < 2:
+            return
+        plot.axes[0].set_limits(ax_limits[0].begin, ax_limits[0].end, 'current')
+
+        signal = signal_limits[0].signal_ref() if signal_limits else None
+        if signal is None or len(plot.axes) < 2:
+            return
+        y_axes = plot.axes[1] if isinstance(plot.axes[1], Collection) else [plot.axes[1]]
+        for (_, stack), y_axis in zip(sorted(plot.signals.items()), y_axes):
+            if any(s is signal for s in stack):
+                y_axis.set_limits(ax_limits[1].begin, ax_limits[1].end, 'current')
+                return
 
     def _draw_time_y_limits(self, plot, begin, end):
         """

--- a/iplotlib/core/tests/test_15_shared_axes_grouping.py
+++ b/iplotlib/core/tests/test_15_shared_axes_grouping.py
@@ -62,6 +62,22 @@ class PlotSignalTsRangeTest(unittest.TestCase):
             BackendParserBase._plot_signal_ts_range(plot), (0.0, 60.0)
         )
 
+    def test_same_instant_matches_whichever_representation_it_carries(self):
+        # A reset restores ts from the axis 'original' as exact integers while the rest
+        # of the group holds float64: past 2**53 a nanosecond does not survive that
+        # round trip, and grouping on the raw values would split the two apart.
+        ts_start = 1_785_426_531_924_363_000  # utcnow() in ns, down to the microsecond
+        ts_end = 1_785_430_131_924_363_000
+        self.assertNotEqual(float(ts_start), ts_start)
+
+        exact = PlotXY()
+        exact.add_signal(_signal_with_ts("exact", ts_start, ts_end))
+        rounded = PlotXY()
+        rounded.add_signal(_signal_with_ts("rounded", float(ts_start), float(ts_end)))
+
+        self.assertEqual(BackendParserBase._plot_signal_ts_range(exact),
+                         BackendParserBase._plot_signal_ts_range(rounded))
+
 
 class PlotXIsTimeTest(unittest.TestCase):
     def test_default_x_expr_is_time(self):

--- a/iplotlib/impl/matplotlib/matplotlibCanvas.py
+++ b/iplotlib/impl/matplotlib/matplotlibCanvas.py
@@ -24,7 +24,6 @@ from pandas.plotting import register_matplotlib_converters
 from iplotLogging import setupLogger
 from iplotlib.core.decimation import minmax_decimate
 from iplotlib.core import (Axis,
-                           RangeAxis,
                            Canvas,
                            BackendParserBase,
                            Plot,
@@ -1371,18 +1370,6 @@ class MatplotlibParser(BackendParserBase):
         self.figure.set_tight_layout("")
 
     def set_focus_plot(self, mpl_axes):
-
-        def get_x_axis_range(focus_plot):
-            if focus_plot is not None and focus_plot.axes is not None and len(focus_plot.axes) > 0 and \
-                    isinstance(focus_plot.axes[0], RangeAxis):
-                return focus_plot.axes[0].begin, focus_plot.axes[0].end
-
-        def set_x_axis_range(focus_plot, x_begin, x_end):
-            if focus_plot is not None and focus_plot.axes is not None and len(focus_plot.axes) > 0 and \
-                    isinstance(focus_plot.axes[0], RangeAxis):
-                focus_plot.axes[0].begin = x_begin
-                focus_plot.axes[0].end = x_end
-
         if isinstance(mpl_axes, MPLAxes):
             ci = self._impl_plot_cache_table.get_cache_item(mpl_axes)
             plot = ci.plot()
@@ -1393,22 +1380,7 @@ class MatplotlibParser(BackendParserBase):
 
         logger.debug(f"Focusing on plot: {id(plot)}, stack_key: {stack_key}")
 
-        if self._focus_plot is not None and plot is None:
-            if self._pm.get_value(self.canvas, 'shared_x_axis') and len(self._focus_plot.axes) > 0 and isinstance(
-                    self._focus_plot.axes[0], RangeAxis):
-                begin, end = get_x_axis_range(self._focus_plot)
-
-                for columns in self.canvas.plots:
-                    for plot_temp in columns:
-                        if plot_temp and not isinstance(self._focus_plot,
-                                                        PlotXYWithSlider) and plot_temp != self._focus_plot and not isinstance(
-                            plot_temp, (PlotXYWithSlider, PlotContourWithSlider)):
-                            logger.debug(
-                                f"Setting range on plot {id(plot_temp)} focused= {id(self._focus_plot)} begin={begin}")
-
-                            if plot_temp.axes[0].original_begin == self._focus_plot.axes[0].original_begin and \
-                                    plot_temp.axes[0].original_end == self._focus_plot.axes[0].original_end:
-                                set_x_axis_range(plot_temp, begin, end)
+        super().set_focus_plot(mpl_axes)
 
         self._focus_plot = plot
         self._focus_plot_stack_key = stack_key

--- a/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
+++ b/iplotlib/impl/pyqtgraph/pyQtGraphCanvas.py
@@ -1762,6 +1762,8 @@ class PyQtGraphParser(BackendParserBase):
             lay.setColumnStretchFactor(c, 1)
 
     def set_focus_plot(self, impl_plot: PlotItem):
+        super().set_focus_plot(impl_plot)
+
         un_focus = self._focus_plot is not None or impl_plot is None
         all_stack = self._pm.get_value(self.canvas, "full_mode_all_stack")
         if un_focus:

--- a/iplotlib/qt/gui/iplotQtCanvas.py
+++ b/iplotlib/qt/gui/iplotQtCanvas.py
@@ -558,15 +558,22 @@ class IplotQtCanvas(QWidget):
 
     def reset_plot_view(self, impl_plot):
         """
-        Restore a single plot to its draw-time view (the "Reset zoom/pan" action),
-        leaving every other plot untouched. Recorded as one undoable command,
-        mirroring the autoscale flow.
+        Restore a plot to its draw-time view (the "Reset zoom/pan" action). Recorded as
+        one undoable command, mirroring the autoscale flow.
+
+        With a shared X axis the time window belongs to the group, so the whole group is
+        restored, Y included: the X propagates on its own, and a plot left holding the Y
+        of the zoom it is no longer showing is the same view Home would have fixed.
         """
         ci = self._parser._impl_plot_cache_table.get_cache_item(impl_plot)
         if not hasattr(ci, 'plot') or not isinstance(ci.plot(), PlotXY):
             return
         self.stage_view_lim_cmd(impl_plot, name='Reset zoom/pan')
         self._parser.set_plot_limits_to_original(impl_plot)
+        if self._parser._pm.get_value(self.get_canvas(), 'shared_x_axis'):
+            for sibling in self._parser._get_all_shared_axes(impl_plot):
+                if sibling is not impl_plot:
+                    self._parser.set_plot_limits_to_original(sibling)
         while len(self._staging_cmds):
             self.commit_view_lim_cmd(impl_plot)
         while len(self._commitd_cmds):

--- a/iplotlib/standalone/tests/test_focus_shared_x.py
+++ b/iplotlib/standalone/tests/test_focus_shared_x.py
@@ -1,0 +1,230 @@
+"""Focus mode against a shared X axis.
+
+A zoom made in focus must leave the canvas as if it had been made without entering
+focus: once unfocused, every plot of the shared group sits in the zoomed window. The
+signal ts matters as much as the axis range, since the group is formed by comparing
+it, so a plot left behind drops out and no later group action reaches it.
+"""
+
+import unittest
+
+import numpy as np
+
+from iplotlib.core.canvas import Canvas
+from iplotlib.core.impl_base import BackendParserBase
+from iplotlib.core.plot import PlotXY
+from iplotlib.core.signal import SignalXY
+from iplotlib.qt.gui.iplotQtCanvasFactory import IplotQtCanvasFactory
+from iplotlib.qt.testing import ensure_qapp
+
+BACKENDS = ('matplotlib', 'pyqt')
+TS_START = 1_754_463_600_000_000_000
+TS_END = 1_754_503_200_000_000_000
+SECOND = 1_000_000_000
+
+
+class FocusSharedXTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+
+    def _build(self, backend: str):
+        canvas = Canvas(2, 1, title="focus_shared_x", shared_x_axis=True)
+        time = np.linspace(TS_START, TS_END, 200).astype(np.int64)
+        for i in range(2):
+            plot = PlotXY()
+            sig = SignalXY(label=f"s{i}")
+            sig.ts_start = TS_START
+            sig.ts_end = TS_END
+            sig.set_data([time, np.sin(time * 1e-18 + i)])
+            plot.add_signal(sig)
+            canvas.add_plot(plot, 0)
+        qt_canvas = IplotQtCanvasFactory.new(backend, canvas=canvas)
+        qt_canvas.set_canvas(canvas)
+        qt_canvas.resize(600, 400)
+        self.app.processEvents()
+        return canvas, qt_canvas
+
+    def _impl_of(self, qt_canvas, plot):
+        """Current implementation plot of *plot*, re-resolved after every rebuild."""
+        return qt_canvas._parser._plot_impl_plot_lut[id(plot)][0]
+
+    def _zoom(self, qt_canvas, plot, window):
+        parser = qt_canvas._parser
+        impl_plot = self._impl_of(qt_canvas, plot)
+        parser.set_oaw_axis_limits(impl_plot, 0, window)
+        BackendParserBase._x_axis_update_callback(parser, impl_plot)
+        self.app.processEvents()
+
+    @staticmethod
+    def _x_window(plot):
+        return plot.axes[0].get_limits('current')
+
+    @staticmethod
+    def _y_window(plot):
+        return plot.axes[1][0].get_limits('current')
+
+    @staticmethod
+    def _ts_window(plot):
+        signal = next(iter(plot.signals.values()))[0]
+        return signal.ts_start, signal.ts_end
+
+    def _assert_window(self, plot, window, msg):
+        begin, end = self._x_window(plot)
+        self.assertAlmostEqual(begin, window[0], delta=SECOND, msg=f"{msg}: X begin")
+        self.assertAlmostEqual(end, window[1], delta=SECOND, msg=f"{msg}: X end")
+
+    def test_zoom_without_focus_moves_the_whole_group(self):
+        """Baseline the focus cases are compared against."""
+        window = (TS_START + 10 * SECOND, TS_END - 10 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                self._zoom(qt_canvas, canvas.plots[0][0], window)
+
+                for i, plot in enumerate(canvas.plots[0]):
+                    self._assert_window(plot, window, f"plot {i}")
+
+    def test_zoom_in_focus_moves_the_whole_group_on_unfocus(self):
+        window = (TS_START + 10 * SECOND, TS_END - 10 * SECOND)
+        zoom_in_focus = (TS_START + 100 * SECOND, TS_START + 200 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+                self._zoom(qt_canvas, sibling, window)
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                self._zoom(qt_canvas, focused, zoom_in_focus)
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                self._assert_window(focused, zoom_in_focus, "focused plot")
+                self._assert_window(sibling, zoom_in_focus, "sibling plot")
+
+    def test_zoom_in_focus_keeps_the_group_together_for_later_actions(self):
+        """The sibling's signal ts must follow, or it drops out of the group."""
+        zoom_in_focus = (TS_START + 100 * SECOND, TS_START + 200 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                self._zoom(qt_canvas, focused, zoom_in_focus)
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                parser = qt_canvas._parser
+                self.assertEqual(self._ts_window(sibling), self._ts_window(focused))
+                shared = parser._get_all_shared_axes(self._impl_of(qt_canvas, focused))
+                self.assertEqual(len(shared), 2, "sibling dropped out of the shared group")
+
+
+    def test_reset_after_unfocus_restores_the_whole_group(self):
+        """mint#153: the reset following a zoom made in focus must reach the group."""
+        zoom_in_focus = (TS_START + 100 * SECOND, TS_START + 200 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+                drawn = self._x_window(sibling)
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                self._zoom(qt_canvas, focused, zoom_in_focus)
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                qt_canvas.reset_plot_view(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+
+                self._assert_window(focused, drawn, "focused plot")
+                self._assert_window(sibling, drawn, "sibling plot")
+
+    def test_undo_after_unfocus_keeps_the_group_together(self):
+        """One undo after unfocus must not split the group."""
+        window = (TS_START + 10 * SECOND, TS_END - 10 * SECOND)
+        zoom_in_focus = (TS_START + 100 * SECOND, TS_START + 200 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+                self._zoom(qt_canvas, sibling, window)
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                self._zoom_with_history(qt_canvas, focused, zoom_in_focus)
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                qt_canvas._parser._hm.undo()
+                self.app.processEvents()
+
+                self.assertEqual(self._x_window(sibling), self._x_window(focused))
+
+    def test_undo_inside_focus_leaves_the_hidden_plots_to_the_rebuild(self):
+        """An undo inside focus reaches plots with no implementation plot: it must not
+        raise, and their window is settled on unfocus."""
+        window = (TS_START + 10 * SECOND, TS_END - 10 * SECOND)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+                drawn = self._x_window(focused)
+                self._zoom_with_history(qt_canvas, sibling, window)
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                qt_canvas._parser._hm.undo()
+                self.app.processEvents()
+
+                # Only the focused plot is built, so only it reverts here.
+                self._assert_window(focused, drawn, "focused plot")
+
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                self._assert_window(sibling, drawn, "sibling plot")
+
+    def test_undo_inside_focus_restores_the_hidden_plots_y_range(self):
+        """The hidden plots take the recorded Y range back too, or they return from
+        focus showing the full window inside the zoomed Y range."""
+        window = (TS_START + 10 * SECOND, TS_END - 10 * SECOND)
+        zoomed_y = (-5.0, 5.0)
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build(backend)
+                parser = qt_canvas._parser
+                focused, sibling = canvas.plots[0][1], canvas.plots[0][0]
+                drawn_y = self._y_window(sibling)
+                self._zoom_with_history(qt_canvas, sibling, window)
+                parser.set_oaw_axis_limits(self._impl_of(qt_canvas, sibling), 1, zoomed_y)
+                self.app.processEvents()
+
+                qt_canvas._full_screen_mode_on(self._impl_of(qt_canvas, focused))
+                self.app.processEvents()
+                qt_canvas._parser._hm.undo()
+                self.app.processEvents()
+                qt_canvas._full_screen_mode_off()
+                self.app.processEvents()
+
+                restored_y = self._y_window(sibling)
+                self.assertAlmostEqual(restored_y[0], drawn_y[0], places=3)
+                self.assertAlmostEqual(restored_y[1], drawn_y[1], places=3)
+
+    def _zoom_with_history(self, qt_canvas, plot, window):
+        """Zoom through the staging/commit/push flow a mouse release goes through."""
+        impl_plot = self._impl_of(qt_canvas, plot)
+        qt_canvas.stage_view_lim_cmd(impl_plot, name='Zoom')
+        self._zoom(qt_canvas, plot, window)
+        while len(qt_canvas._staging_cmds):
+            qt_canvas.commit_view_lim_cmd(impl_plot)
+        while len(qt_canvas._commitd_cmds):
+            qt_canvas.push_view_lim_cmd()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -196,25 +196,32 @@ class ResetViewTest(unittest.TestCase):
                 self.assertEqual(calls['get_data'], 0)
                 self.assertEqual(len(other_signal.x_data), full_len)
 
-    def test_reset_plot_view_keeps_the_other_plots_y_range(self):
-        # Only the plot the action was invoked on gets its Y reset.
+    def test_reset_plot_view_restores_the_whole_group_y_range(self):
+        # A rubber-band zoom narrows the Y of the plot it is drawn on and leaves the
+        # rest of the group alone, so a reset invoked on any of them has to return
+        # every Y as well: the X comes back on its own, and a plot left holding the Y
+        # of a window it no longer shows is the view Home would have fixed.
         window = (TS_START + 100 * SECOND, TS_END - 100 * SECOND)
-        other_y = (-5.0, 5.0)
+        zoomed_y = (-5.0, 5.0)
         for backend in ('matplotlib', 'pyqt'):
-            with self.subTest(backend=backend):
-                canvas, qt_canvas = self._build_shared(backend)
-                parser = qt_canvas._parser
-                impl_plots = self._impl_plots(canvas, qt_canvas)
-                self._shared_zoom(qt_canvas, impl_plots[0], window)
-                parser.set_oaw_axis_limits(impl_plots[0], 1, other_y)
-                self.app.processEvents()
+            for clicked in (0, 1):
+                with self.subTest(backend=backend, clicked=clicked):
+                    canvas, qt_canvas = self._build_shared(backend)
+                    parser = qt_canvas._parser
+                    impl_plots = self._impl_plots(canvas, qt_canvas)
+                    drawn_y = [parser.get_oaw_axis_limits(impl, 1) for impl in impl_plots]
 
-                qt_canvas.reset_plot_view(impl_plots[1])
-                self.app.processEvents()
+                    self._shared_zoom(qt_canvas, impl_plots[0], window)
+                    parser.set_oaw_axis_limits(impl_plots[0], 1, zoomed_y)
+                    self.app.processEvents()
 
-                kept = parser.get_oaw_axis_limits(self._impl_plots(canvas, qt_canvas)[0], 1)
-                self.assertAlmostEqual(kept[0], other_y[0], places=3)
-                self.assertAlmostEqual(kept[1], other_y[1], places=3)
+                    qt_canvas.reset_plot_view(impl_plots[clicked])
+                    self.app.processEvents()
+
+                    for impl, (begin, end) in zip(self._impl_plots(canvas, qt_canvas), drawn_y):
+                        restored = parser.get_oaw_axis_limits(impl, 1)
+                        self.assertAlmostEqual(restored[0], begin, places=3)
+                        self.assertAlmostEqual(restored[1], end, places=3)
 
     def test_reset_plot_view_leaves_the_others_alone_without_shared_x(self):
         # Without a shared X axis the action stays limited to one plot.

--- a/iplotlib/standalone/tests/test_reset_view.py
+++ b/iplotlib/standalone/tests/test_reset_view.py
@@ -4,6 +4,8 @@ After a zoom, both actions must restore the axis range captured at draw time,
 reusing the same view-limit plumbing as undo/redo. Home is verified to be a
 single undoable command so one undo reverts the whole reset, and to redraw
 from the draw-time snapshot without issuing any data-access request.
+
+With a shared X axis the per-plot reset is verified over the whole group.
 """
 
 import copy
@@ -14,11 +16,16 @@ from iplotProcessing.core import BufferObject
 
 from iplotlib.core.canvas import Canvas
 from iplotlib.core.commands.axes_range import IplotAxesRangeCmd
+from iplotlib.core.impl_base import BackendParserBase
 from iplotlib.core.plot import PlotXY
 from iplotlib.core.signal import SignalXY
 from iplotlib.qt.gui.iplotQtCanvasFactory import IplotQtCanvasFactory
 from iplotlib.qt.gui.iplotQtMainWindow import IplotQtMainWindow
 from iplotlib.qt.testing import ensure_qapp
+
+TS_START = 1_754_463_600_000_000_000
+TS_END = 1_754_503_200_000_000_000
+SECOND = 1_000_000_000
 
 
 def _make_canvas() -> Canvas:
@@ -29,6 +36,21 @@ def _make_canvas() -> Canvas:
     signal.set_data([x, np.sin(x)])
     plot.add_signal(signal)
     core.add_plot(plot, 0)
+    return core
+
+
+def _make_shared_time_canvas(shared: bool = True) -> Canvas:
+    """Two time plots, the smallest canvas a shared time group can be formed on."""
+    core = Canvas(2, 1, title="reset_view_shared", shared_x_axis=shared)
+    time = np.linspace(TS_START, TS_END, 200).astype(np.int64)
+    for i in range(2):
+        plot = PlotXY()
+        signal = SignalXY(label=f"s{i}")
+        signal.ts_start = TS_START
+        signal.ts_end = TS_END
+        signal.set_data([time, np.sin(np.linspace(0, 6, 200) + i)])
+        plot.add_signal(signal)
+        core.add_plot(plot, 0)
     return core
 
 
@@ -103,6 +125,114 @@ class ResetViewTest(unittest.TestCase):
                 restored = self._x_range(qt_canvas)
                 self.assertAlmostEqual(restored[0], original[0], places=3)
                 self.assertAlmostEqual(restored[1], original[1], places=3)
+
+    def _build_shared(self, backend: str, shared: bool = True):
+        canvas = _make_shared_time_canvas(shared)
+        qt_canvas = IplotQtCanvasFactory.new(backend, canvas=canvas)
+        qt_canvas.set_canvas(canvas)
+        qt_canvas.resize(600, 400)
+        self.app.processEvents()
+        return canvas, qt_canvas
+
+    @staticmethod
+    def _impl_plots(canvas, qt_canvas):
+        """Implementation plots in canvas order, re-resolved after every redraw."""
+        lut = qt_canvas._parser._plot_impl_plot_lut
+        return [lut[id(plot)][0] for plot in canvas.plots[0]]
+
+    def _shared_zoom(self, qt_canvas, impl_plot, window):
+        """Zoom the way a mouse gesture does, so the shared-x propagation runs."""
+        parser = qt_canvas._parser
+        parser.set_oaw_axis_limits(impl_plot, 0, window)
+        BackendParserBase._x_axis_update_callback(parser, impl_plot)
+        self.app.processEvents()
+
+    def test_reset_plot_view_restores_the_whole_shared_group(self):
+        window = (TS_START + 100 * SECOND, TS_END - 100 * SECOND)
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build_shared(backend)
+                parser = qt_canvas._parser
+                impl_plots = self._impl_plots(canvas, qt_canvas)
+                drawn = [parser.get_oaw_axis_limits(impl, 0) for impl in impl_plots]
+
+                self._shared_zoom(qt_canvas, impl_plots[0], window)
+                for impl in impl_plots:
+                    self.assertAlmostEqual(parser.get_oaw_axis_limits(impl, 0)[0],
+                                           window[0], delta=SECOND)
+
+                # Invoked on the plot the zoom was not made on: the whole group follows.
+                qt_canvas.reset_plot_view(impl_plots[1])
+                self.app.processEvents()
+
+                for impl, (begin, end) in zip(self._impl_plots(canvas, qt_canvas), drawn):
+                    restored = parser.get_oaw_axis_limits(impl, 0)
+                    self.assertAlmostEqual(restored[0], begin, delta=SECOND)
+                    self.assertAlmostEqual(restored[1], end, delta=SECOND)
+
+    def test_reset_plot_view_restores_the_group_without_data_access(self):
+        # Same contract as Home: the restore is served from the draw-time snapshots.
+        window = (TS_START + 100 * SECOND, TS_END - 100 * SECOND)
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build_shared(backend)
+                impl_plots = self._impl_plots(canvas, qt_canvas)
+                other_signal = next(iter(canvas.plots[0][0].signals.values()))[0]
+                full_len = len(other_signal.x_data)
+                self._shared_zoom(qt_canvas, impl_plots[0], window)
+
+                calls = {'get_data': 0}
+                original_get_data = other_signal.get_data
+
+                def spied_get_data():
+                    calls['get_data'] += 1
+                    return original_get_data()
+
+                other_signal.get_data = spied_get_data
+
+                qt_canvas.reset_plot_view(impl_plots[1])
+                self.app.processEvents()
+
+                self.assertEqual(calls['get_data'], 0)
+                self.assertEqual(len(other_signal.x_data), full_len)
+
+    def test_reset_plot_view_keeps_the_other_plots_y_range(self):
+        # Only the plot the action was invoked on gets its Y reset.
+        window = (TS_START + 100 * SECOND, TS_END - 100 * SECOND)
+        other_y = (-5.0, 5.0)
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build_shared(backend)
+                parser = qt_canvas._parser
+                impl_plots = self._impl_plots(canvas, qt_canvas)
+                self._shared_zoom(qt_canvas, impl_plots[0], window)
+                parser.set_oaw_axis_limits(impl_plots[0], 1, other_y)
+                self.app.processEvents()
+
+                qt_canvas.reset_plot_view(impl_plots[1])
+                self.app.processEvents()
+
+                kept = parser.get_oaw_axis_limits(self._impl_plots(canvas, qt_canvas)[0], 1)
+                self.assertAlmostEqual(kept[0], other_y[0], places=3)
+                self.assertAlmostEqual(kept[1], other_y[1], places=3)
+
+    def test_reset_plot_view_leaves_the_others_alone_without_shared_x(self):
+        # Without a shared X axis the action stays limited to one plot.
+        window = (TS_START + 100 * SECOND, TS_END - 100 * SECOND)
+        for backend in ('matplotlib', 'pyqt'):
+            with self.subTest(backend=backend):
+                canvas, qt_canvas = self._build_shared(backend, shared=False)
+                parser = qt_canvas._parser
+                impl_plots = self._impl_plots(canvas, qt_canvas)
+                self._shared_zoom(qt_canvas, impl_plots[0], window)
+                zoomed = parser.get_oaw_axis_limits(impl_plots[0], 0)
+
+                qt_canvas.reset_plot_view(impl_plots[1])
+                self.app.processEvents()
+
+                kept = parser.get_oaw_axis_limits(self._impl_plots(canvas, qt_canvas)[0], 0)
+                self.assertAlmostEqual(kept[0], zoomed[0], delta=SECOND)
+                self.assertAlmostEqual(kept[1], zoomed[1], delta=SECOND)
 
     def test_home_is_single_undoable_command(self):
         for backend in ('matplotlib', 'pyqt'):


### PR DESCRIPTION
Focus builds only the focused plot, so a zoom made there left the others behind: on unfocus they either stayed put (pyqtgraph) or came back aligned but empty (matplotlib, which moved their axes without their signal ts). Window and ts now go to the model of the plots focus hides, so the rebuild draws them over the zoomed window and the reset and undo that follow reach the whole group again.

An undo made inside focus reached those plots too and crashed on the missing implementation plot. Their recorded ranges go to the model instead, Y included, so they do not come back holding the zoomed Y range.

This replaces the matplotlib-only propagation; both backends share one path now.