### PR TITLE
Disable the mini-map while streaming (#154)

### DIFF
--- a/iplotlib/core/canvas.py
+++ b/iplotlib/core/canvas.py
@@ -82,7 +82,8 @@ class Canvas(ABC):
     auto_refresh : int
         Auto redraw canvas every X seconds
     show_minimap : bool
-        Show a mini-map below the main plot. Only valid with a single visible plot.
+        Show a mini-map below the main plot. Only valid with a single visible plot
+        and while not streaming.
     _type : str
         type of the canvas
     max_diff: int
@@ -344,6 +345,11 @@ class Canvas(ABC):
                                 signal.merge(map_old_signals[key])
 
     def is_minimap_eligible(self) -> bool:
+        # The mini-map is a frozen overview of the window captured at draw time. A
+        # streaming x-axis keeps moving past that window and its data snapshot is
+        # never refreshed, so there is nothing meaningful left to show.
+        if self.streaming:
+            return False
         target = self.get_minimap_target_plot()
         if target is None:
             return False

--- a/iplotlib/qt/gui/iplotCanvasToolbar.py
+++ b/iplotlib/qt/gui/iplotCanvasToolbar.py
@@ -65,7 +65,8 @@ class IplotQtCanvasToolbar(QToolBar):
         self.minimapAction = QAction(create_icon('minimap', 'svg'), 'Mini-map', self)
         self.minimapAction.setCheckable(True)
         self.minimapAction.setEnabled(False)
-        self.minimapAction.setToolTip('Show mini-map (available when a single plot is visible)')
+        self.minimapAction.setToolTip('Show mini-map (available when a single plot is visible, '
+                                      'except while streaming)')
         self.addAction(self.minimapAction)
         self.addSeparator()
 

--- a/iplotlib/standalone/tests/test_main_window.py
+++ b/iplotlib/standalone/tests/test_main_window.py
@@ -304,6 +304,12 @@ class MinimapStateTest(unittest.TestCase):
         c2.add_plot(PlotXYWithSlider(), 0)
         self.assertFalse(c2.is_minimap_eligible())
 
+    def test_eligibility_rejects_streaming(self):
+        c = _canvas_with_signal()
+        self.assertTrue(c.is_minimap_eligible())
+        c.streaming = True
+        self.assertFalse(c.is_minimap_eligible())
+
     def test_baseline_snapshot_roundtrip(self):
         c = Canvas(1, 1)
         c.snapshot_minimap_baseline(10, 20)
@@ -371,6 +377,20 @@ class MinimapToolbarTest(unittest.TestCase):
             self._add_canvas(win, multi)
             win.refresh_minimap_availability()
             self.assertFalse(win.toolBar.minimapAction.isEnabled())
+        finally:
+            win.close()
+
+    def test_minimap_action_disabled_and_turned_off_while_streaming(self):
+        win = IplotQtMainWindow()
+        try:
+            core = _canvas_with_signal()
+            core.show_minimap = True
+            core.streaming = True
+            self._add_canvas(win, core)
+            win.refresh_minimap_availability()
+            self.assertFalse(win.toolBar.minimapAction.isEnabled())
+            self.assertFalse(win.toolBar.minimapAction.isChecked())
+            self.assertFalse(core.show_minimap)
         finally:
             win.close()
 


### PR DESCRIPTION
Reported in iplot-viz/mint#154: the mini-map misbehaves during streaming, so it should not be offered at all.

## Why it breaks

The mini-map is a frozen overview of the window captured at draw time. Its baseline x-range and its per-signal data snapshot are taken once and never refreshed, while a streaming x-axis keeps moving past that window. The overview goes stale and the viewport overlay drifts off the map.

## Change

`Canvas.is_minimap_eligible()` now rejects a streaming canvas. That is the single check already consulted by the toolbar action and by both backends, so the button greys out and the panel hides without touching any render path. Tooltip and docstring updated to match.

## Verification

- Full suite: 559 passed, 3 skipped (the usual ones).
- Offscreen smoke on both backends: the panel is visible with the mini-map on, and hidden as soon as the canvas enters streaming; the toolbar action ends up disabled, unchecked and with `show_minimap` cleared.
- Removing the guard turns the two new tests red, so they do cover it.
- No image baseline is affected: no rendering test enables `show_minimap` or `streaming`.

## Note

`canvas.streaming` is only cleared by the next `build()`, so after pressing Stop the mini-map stays greyed out until the next Draw. That is intentional: the data on screen and the axis are still the streaming ones, so the overview would still be wrong.

Needs to be merged before the matching mint PR.