### PR TITLE
Read the statistics from the plotted X buffer (#160)

### DIFF
--- a/iplotlib/qt/gui/IplotQtStatistics.py
+++ b/iplotlib/qt/gui/IplotQtStatistics.py
@@ -260,7 +260,9 @@ class IplotQtStatistics(QWidget):
                 # Insert new row
                 self.table.insertRow(idx)
                 x_type=1 #1 means date, 2 means rel time and 3 else
-                x_unit = signal.data_store[0].unit
+                # Unit of the plotted X: an expression clears it, so a transformed
+                # axis is not read as a duration.
+                x_unit = getattr(signal.x_data, 'unit', None)
                 # Add Statistics to the table
                 if has_envelope > 0:
                     curves = line
@@ -279,8 +281,10 @@ class IplotQtStatistics(QWidget):
 
                     # Statistics come from the buffered dataset, not the painted
                     # curves: while streaming the display is decimated for paint
-                    # speed and would under-report the samples.
-                    x_data = np.asarray(signal.data_store[0])
+                    # speed and would under-report the samples. X is the buffer the
+                    # backend paints; the raw store keeps the time base, which an x
+                    # expression no longer matches.
+                    x_data = np.asarray(signal.x_data)
                     y_min = np.asarray(signal.data_store[1])
                     y_max = np.asarray(signal.data_store[2])
                     y_mean = np.asarray(signal.data_store[3])
@@ -383,13 +387,12 @@ class IplotQtStatistics(QWidget):
                     # The rows correspond to the signals and their corresponding stacks
                     self.table.setItem(idx, 0, QTableWidgetItem(signal_name))
 
-                    # Prefer the buffered dataset (see envelope case) so the
+                    # Prefer the processed buffers (see envelope case) so the
                     # display decimation does not under-report; fall back to the
-                    # painted line for shapes the buffer cannot describe per
+                    # painted line for shapes the buffers cannot describe per
                     # line (e.g. 2D signals drawn as one line per column).
-                    ds = signal.data_store
-                    buf_x = np.asarray(ds[0]) if len(ds) > 0 else np.asarray([])
-                    buf_y = np.asarray(ds[1]) if len(ds) > 1 else np.asarray([])
+                    buf_x = np.asarray(signal.x_data)
+                    buf_y = np.asarray(signal.y_data)
                     use_buffer = (buf_y.ndim == 1 and buf_y.size > 0
                                   and buf_x.size == buf_y.size)
                     if use_buffer:

--- a/iplotlib/standalone/tests/test_backend_behavior.py
+++ b/iplotlib/standalone/tests/test_backend_behavior.py
@@ -216,6 +216,96 @@ class StatsVerticalZoomTest(unittest.TestCase):
                 self.assertEqual(narrow, wide)
 
 
+class StatsXExpressionTest(unittest.TestCase):
+    """Regression: an expression on the X column must not blank the statistics.
+
+    The stats masked the raw time base with the visible window. An x expression
+    (``${self}.time-${self}.time[0]``, the MCTF_processing workspaces) leaves the
+    two in different units, so every sample fell outside the window and the row
+    reported 0 samples with no min/avg/max.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+
+    @staticmethod
+    def _canvas(x_expr=None):
+        """Signal sampled over an absolute nanosecond time base, optionally
+        plotted against a relative X expression."""
+        core = Canvas(1, 1, title="x_expr")
+        time = np.linspace(1785229200000000000, 1785402000000000000, 500).astype(np.int64)
+        y = np.sin(np.linspace(0, 10, 500))
+        sig = SignalXY(label="s")
+        sig.data_access_enabled = False
+        sig.set_data([time, y])
+        if x_expr is not None:
+            sig.x_expr = x_expr
+            sig._process_data()
+        plot = PlotXY()
+        plot.add_signal(sig)
+        core.add_plot(plot, 0)
+        return core, sig
+
+    def _qt_canvas(self, backend, canvas, sig):
+        qt_canvas = IplotQtCanvasFactory.new(backend, canvas=canvas)
+        qt_canvas.set_canvas(canvas)
+        qt_canvas.resize(400, 300)
+        self.app.processEvents()
+        impl_plot = qt_canvas._parser._signal_impl_plot_lut.get(
+            qt_canvas._parser.signal_lut_key(sig))
+        self.assertIsNotNone(impl_plot)
+        return qt_canvas, impl_plot
+
+    def _row(self, qt_canvas, canvas):
+        qt_canvas.stats(canvas)
+        self.app.processEvents()
+        table = qt_canvas._stats_table.table
+        self.assertEqual(table.rowCount(), 1)
+        return [table.item(0, col) for col in range(table.columnCount())]
+
+    def _set_x_view(self, impl_plot, backend, lo, hi):
+        if backend == 'pyqt':
+            impl_plot.getViewBox().setXRange(lo, hi, padding=0)
+        else:
+            impl_plot.set_xlim(lo, hi)
+        self.app.processEvents()
+
+    def test_x_expression_keeps_the_statistics(self):
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, sig = self._canvas("${self}.time-${self}.time[0]")
+                # Plotted X and raw time base apart: the mismatch under test.
+                self.assertNotEqual(float(sig.x_data[0]), float(sig.data_store[0][0]))
+
+                qt_canvas, _ = self._qt_canvas(backend, canvas, sig)
+                row = self._row(qt_canvas, canvas)
+                self.assertEqual(row[6].data(Qt.ItemDataRole.UserRole), 500)
+                for col in (1, 2, 3):
+                    self.assertIsNotNone(row[col])
+
+    def test_x_expression_count_follows_the_visible_window(self):
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, sig = self._canvas("${self}.time-${self}.time[0]")
+                qt_canvas, impl_plot = self._qt_canvas(backend, canvas, sig)
+
+                # Half of the transformed range: the mask must read the window in
+                # the units of the expression, not those of the time base.
+                self._set_x_view(impl_plot, backend, 0.0, float(sig.x_data[-1]) / 2)
+                samples = self._row(qt_canvas, canvas)[6].data(Qt.ItemDataRole.UserRole)
+                self.assertGreater(samples, 0)
+                self.assertLess(samples, 500)
+
+    def test_default_x_expression_is_unchanged(self):
+        for backend in BACKENDS:
+            with self.subTest(backend=backend):
+                canvas, sig = self._canvas()
+                qt_canvas, _ = self._qt_canvas(backend, canvas, sig)
+                self.assertEqual(
+                    self._row(qt_canvas, canvas)[6].data(Qt.ItemDataRole.UserRole), 500)
+
+
 class AutoscaleTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
The stats masked the raw time base (data_store[0]) with the visible window, which comes from the axis. An expression on the X column leaves the two in different units: with x = ${self}.time-${self}.time[0] the window spans 0 to the duration while the store still holds epoch nanoseconds, so every sample fell outside the mask and the row reported 0 samples with no min/avg/max.

Mask the processed buffers instead (x_data/y_data): they are what the backend paints and, unlike the painted curves, are not decimated for display. With the default x expression they are the store itself, so that path is unchanged. The X unit now comes from x_data too — an expression clears it, so a transformed axis is no longer read as a duration.

Add StatsXExpressionTest covering both backends.